### PR TITLE
Force ranch_transport behavior to compile first.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{erl_first_files, ["src/ranch_transport.erl"]}.
+
 {erl_opts, [
 %%	bin_opt_info,
 %%	warn_missing_spec,


### PR DESCRIPTION
This addresses the error when compiling ranch:

```
==> ranch (clean)
==> ranch (compile)
Compiled src/ranch_transport.erl
compile: warnings being treated as errors
Compiled src/ranch_sup.erl
src/ranch_tcp.erl:21: behaviour ranch_transport undefined
```
