### PR TITLE
Allow raw socket options for TCP.

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -169,6 +169,11 @@ filter_options([Opt = {Key, _}|Tail], AllowedKeys, Acc) ->
 	case lists:member(Key, AllowedKeys) of
 		true -> filter_options(Tail, AllowedKeys, [Opt|Acc]);
 		false -> filter_options(Tail, AllowedKeys, Acc)
+	end;
+filter_options([Opt = {raw, _, _, _}|Tail], AllowedKeys, Acc) ->
+	case lists:member(raw, AllowedKeys) of
+		true -> filter_options(Tail, AllowedKeys, [Opt|Acc]);
+		false -> filter_options(Tail, AllowedKeys, Acc)
 	end.
 
 %% @doc Add an option to a list, but only if it wasn't previously set.

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -95,7 +95,7 @@ listen(Opts) ->
 	%% first argument.
 	ssl:listen(0, ranch:filter_options(Opts2,
 		[backlog, cacertfile, certfile, ciphers, ip,
-			keyfile, nodelay, password, port, verify],
+			keyfile, nodelay, password, port, raw, verify],
 		[binary, {active, false}, {packet, raw},
 			{reuseaddr, true}, {nodelay, true}])).
 

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -70,7 +70,7 @@ listen(Opts) ->
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.
-	gen_tcp:listen(0, ranch:filter_options(Opts2, [backlog, ip, nodelay, port],
+	gen_tcp:listen(0, ranch:filter_options(Opts2, [backlog, ip, nodelay, port, raw],
 		[binary, {active, false}, {packet, raw},
 			{reuseaddr, true}, {nodelay, true}])).
 


### PR DESCRIPTION
This patch lets the user set and use raw socket options as described in
inet:setopts/2 documentation.

The raw options can be useful to use TCP features that are platform-
specific and not supported in inet in general, such as TCP_DEFER_ACCEPT
or TCP_LINGER2 in linux stacks, for example.
