### PR TITLE
Setting max connections from integer to infinity causes listener to crash soon after

### DIFF
--- a/src/ranch_listener.erl
+++ b/src/ranch_listener.erl
@@ -127,9 +127,12 @@ handle_call(get_max_connections, _From, State=#state{max_conns=MaxConns}) ->
 handle_call({set_max_connections, MaxConnections}, _From,
 		State=#state{ref=Ref, max_conns=CurrMax, rm_diff=CurrDiff}) ->
 	RmDiff = case {MaxConnections, CurrMax} of
+		{infinity, infinity} -> % stay current
+			CurrDiff;
 		{infinity, _} -> % moving to infinity, delete connection key
+			Count = ranch_server:count_connections(self()),
 			ranch_server:remove_connections_counter(self()),
-			0;
+			CurrDiff + Count;
 		{_, infinity} -> % moving away from infinity, create connection key
 			ranch_server:add_connections_counter(self()),
 			CurrDiff;

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -294,7 +294,11 @@ tcp_infinity_max_connections(_) ->
 	ranch:set_max_connections(tcp_infinity_max_connections, 10),
 	0 = ranch_server:count_connections(ListenerPid),
 	10 = receive_loop(connected, 1000),
-	10 = ranch_server:count_connections(ListenerPid). % count could be off
+	10 = ranch_server:count_connections(ListenerPid), % count could be off
+	ranch:set_max_connections(tcp_infinity_max_connections, infinity),
+	Ref = monitor(process, ListenerPid),
+	receive {'DOWN', _, _, Reason} -> error(Reason) after 2500 -> ok end,
+	true = demonitor(Ref, [flush, info]).
 
 tcp_upgrade(_) ->
 	receive after 20000 -> ok end,


### PR DESCRIPTION
Currently once max connections has been relaxed to infinity (from an integer) the listener will still receive 'DOWN' messages. As rm_diff has been set to 0, the first one of these will cause the listener to call ranch_server:remove_connection(self()). However the ets object no longer exists, so the listener fails with badarg.

As the count is effectively 0, and this is the value returned by count_connections/1, the rm_diff should be the total number of active monitors. This is current rm_diff + current connection count. Therefore a 'DOWN' message should never trigger a ranch_server:remove_connection/2 on the listener because once rm_diff = 0 there are no more monitors.

This patch has the added bonus of preventing a potential negative count if the max connection limit is set back to an integer, which is currently possible (if the listener did not crash).
