### PR TITLE
Remove an unsupported key from the .app file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ranch
 =====
 
-Ranch is a socket acceptor pool for TCP protocols.
+Ranch is a socket acceptor pool for TCP protocols. It is a reusable library for building networked applications.
 
 Goals
 -----

--- a/src/ranch.app.src
+++ b/src/ranch.app.src
@@ -15,7 +15,6 @@
 {application, ranch, [
 	{id, "Ranch"},
 	{description, "Socket acceptor pool for TCP protocols."},
-	{sub_description, "Reusable library for building networked applications."},
 	{vsn, "0.6.2"},
 	{modules, []},
 	{registered, [ranch_sup, ranch_server]},


### PR DESCRIPTION
Key `sub_description` currently specified in the .app files isn't recognized by Erlang release tools (`systools` and `reltool`). This is a non-standard key that is unsupported by those tools, causing warnings every time the .app files is processed by those tools (which happens when creating releases or calling most of the functions available in either `systools` or `reltool` modules).

The list of keys supported by the release tools is available here: http://www.erlang.org/doc/design_principles/applications.html#id73724
