### PR TITLE
Improve SSL accept

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -125,7 +125,14 @@ child_spec(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts)
 %% the protocol process before starting to use it.
 -spec accept_ack(any()) -> ok.
 accept_ack(Ref) ->
-	receive {shoot, Ref} -> ok end.
+	receive
+		{shoot, Ref, undefined} -> ok;
+		{shoot, Ref, Handshake} ->
+			case Handshake() of
+				ok -> ok;
+				{error, _Reason} -> exit(normal)
+			end
+	end.
 
 %% @doc Remove the calling process' connection from the pool.
 %%

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -118,11 +118,12 @@ listen(Opts) ->
 %% @see ssl:transport_accept/2
 %% @see ssl:ssl_accept/2
 -spec accept(ssl:sslsocket(), timeout())
-	-> {ok, ssl:sslsocket()} | {error, closed | timeout | atom() | tuple()}.
+    -> {ok, ssl:sslsocket(), ranch_transport:handshake()}
+	| {error, closed | timeout | atom() | tuple()}.
 accept(LSocket, Timeout) ->
 	case ssl:transport_accept(LSocket, Timeout) of
 		{ok, CSocket} ->
-			ssl_accept(CSocket, Timeout);
+			{ok, CSocket, fun() -> ssl_accept(CSocket, Timeout) end};
 		{error, Reason} ->
 			{error, Reason}
 	end.
@@ -222,13 +223,13 @@ close(Socket) ->
 %% was given, or because we've decided to use 5000ms instead of infinity.
 %% This value should be reasonable enough for the moment.
 -spec ssl_accept(ssl:sslsocket(), timeout())
-	-> {ok, ssl:sslsocket()} | {error, {ssl_accept, atom()}}.
+	-> ok | {error, {ssl_accept, atom()}}.
 ssl_accept(Socket, infinity) ->
 	ssl_accept(Socket, 5000);
 ssl_accept(Socket, Timeout) ->
 	case ssl:ssl_accept(Socket, Timeout) of
 		ok ->
-			{ok, Socket};
+			ok;
 		{error, Reason} ->
 			{error, {ssl_accept, Reason}}
 	end.

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -17,6 +17,9 @@
 
 -type socket() :: any().
 -type opts() :: any().
+-type handshake() :: undefined | fun(() -> ok | {error, term()}).
+
+-export_type([handshake/0]).
 
 %% Name of the transport.
 -callback name() -> atom().
@@ -40,9 +43,13 @@
 %% ranch:get_port/1 instead.
 -callback listen(opts()) -> {ok, socket()} | {error, atom()}.
 
-%% Accept connections with the given listening socket.
+%% Accept connections with the given listening socket. If handshaking is
+%% required after the initial accept a fun is also returned. The fun should
+%% accept a timeout value and return ok on success. It will be called by
+%% ranch:accept_ack/2.
 -callback accept(socket(), timeout())
-	-> {ok, socket()} | {error, closed | timeout | atom() | tuple()}.
+    -> {ok, socket()} | {ok, socket(), handshake()}
+	| {error, closed | timeout | atom() | tuple()}.
 
 %% Experimental. Open a connection to the given host and port number.
 -callback connect(string(), inet:port_number(), opts())


### PR DESCRIPTION
Move ssl handshaking to `ranch:accept_ack/2`. This stops acceptors being hogged by slow or bad clients and should significantly improve ssl accept latency under load.
