### PR TITLE
Add ranch_server state recovery

### DIFF
--- a/src/ranch_server.erl
+++ b/src/ranch_server.erl
@@ -114,7 +114,9 @@ count_connections(Ref) ->
 
 %% @private
 init([]) ->
-	{ok, #state{}}.
+	Monitors = [{{erlang:monitor(process, Pid), Pid}, Ref} ||
+		[Ref, Pid] <- ets:match(?TAB, {{conns_sup, '$1'}, '$2'})],
+	{ok, #state{monitors=Monitors}}.
 
 %% @private
 handle_call({set_new_listener_opts, Ref, MaxConns, Opts}, _, State) ->


### PR DESCRIPTION
When ranch_server crashes it will now remonitor previously registered
ranch_conns_sup processes so they can be removed from the registry when
they die.

This replaces part of a previous version of #43.
