### PR TITLE
Make rebar compile behaviour files first

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{erl_first_files, ["src/ranch_transport.erl"]}.


### PR DESCRIPTION
This setting in rebar.conf will cause rebar to compile
ranch_transport.erl first and thus remove the warning produced
when compiling for the first time.
