### PR TITLE
Use previous ecc workaround for R16B02 as well

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -281,7 +281,7 @@ ssl_accept(Socket, Timeout) ->
 -spec unbroken_cipher_suites() -> [ssl:erl_cipher_suite()].
 unbroken_cipher_suites() ->
 	case proplists:get_value(ssl_app, ssl:versions()) of
-		"5.3" ->
+		Version when Version =:= "5.3"; Version =:= "5.3.1" ->
 			lists:filter(fun(Suite) ->
 				string:left(atom_to_list(element(1, Suite)), 4) =/= "ecdh"
 			end, ssl:cipher_suites());


### PR DESCRIPTION
The implementation of elliptic-curve ciphers that has been introduced in
R16B01 is still incomplete (and broken).  This makes our previous
workaround (see c0c09a1311) work for R16B02 as well.
