### PR TITLE
Implements ranch_transport:connect/4.

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -31,6 +31,7 @@
 -export([listen/1]).
 -export([accept/2]).
 -export([connect/3]).
+-export([connect/4]).
 -export([recv/3]).
 -export([send/2]).
 -export([sendfile/2]).
@@ -182,6 +183,17 @@ accept(LSocket, Timeout) ->
 connect(Host, Port, Opts) when is_integer(Port) ->
 	ssl:connect(Host, Port,
 		Opts ++ [binary, {active, false}, {packet, raw}]).
+
+%% @private Experimental. Open a connection to the given host and port number.
+%% @see ssl:connect/4
+%% @todo Probably filter Opts?
+-spec connect(inet:ip_address() | inet:hostname(),
+	inet:port_number(), any(), timeout())
+	-> {ok, inet:socket()} | {error, atom()}.
+connect(Host, Port, Opts, Timeout) when is_integer(Port) ->
+	ssl:connect(Host, Port,
+		Opts ++ [binary, {active, false}, {packet, raw}],
+		Timeout).
 
 %% @doc Receive data from a socket in passive mode.
 %% @see ssl:recv/3

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -25,6 +25,7 @@
 -export([listen/1]).
 -export([accept/2]).
 -export([connect/3]).
+-export([connect/4]).
 -export([recv/3]).
 -export([send/2]).
 -export([sendfile/2]).
@@ -98,6 +99,18 @@ accept(LSocket, Timeout) ->
 connect(Host, Port, Opts) when is_integer(Port) ->
 	gen_tcp:connect(Host, Port,
 		Opts ++ [binary, {active, false}, {packet, raw}]).
+
+%% @private Experimental. Open a connection to the given host and port
+%% number with a timeout.
+%% @see gen_tcp:connect/4
+%% @todo Probably filter Opts?
+-spec connect(inet:ip_address() | inet:hostname(),
+	inet:port_number(), any(), timeout())
+	-> {ok, inet:socket()} | {error, atom()}.
+connect(Host, Port, Opts, Timeout) when is_integer(Port) ->
+	gen_tcp:connect(Host, Port,
+		Opts ++ [binary, {active, false}, {packet, raw}],
+		Timeout).
 
 %% @doc Receive data from a socket in passive mode.
 %% @see gen_tcp:recv/3

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -52,6 +52,11 @@
 -callback connect(string(), inet:port_number(), opts())
 	-> {ok, socket()} | {error, atom()}.
 
+%% Experimental. Open a connection to the given host and port number
+%% with a timeout.
+-callback connect(string(), inet:port_number(), opts(), timeout())
+	-> {ok, socket()} | {error, atom()}.
+
 %% Receive data from a socket in passive mode.
 -callback recv(socket(), non_neg_integer(), timeout())
 	-> {ok, any()} | {error, closed | timeout | atom()}.


### PR DESCRIPTION
This addition to ranch_transport(s) allows setting a non-default connect timeout. The default connect timeout of 5000ms is often not ideal, and this patch allows overriding it in the same way the standard OTP libraries do.
