### PR TITLE
Add gen_server reverse example

### DIFF
--- a/examples/tcp_reverse/Makefile
+++ b/examples/tcp_reverse/Makefile
@@ -1,0 +1,6 @@
+PROJECT = tcp_reverse
+
+DEPS = ranch
+dep_ranch = pkg://ranch 0.9.0
+
+include ../../erlang.mk

--- a/examples/tcp_reverse/README.md
+++ b/examples/tcp_reverse/README.md
@@ -1,0 +1,29 @@
+Ranch TCP Reverse
+=================
+
+This example uses a gen_server to handle a protocol to revese input. See
+reverse_protocol.erl for the implementation, and documentation at
+the following URL:
+
+http://ninenines.eu/docs/en/ranch/HEAD/guide/protocols/#using_gen_server
+
+To build the example:
+``` bash
+$ make
+```
+
+To start the release in the foreground:
+
+``` bash
+$ ./_rel/bin/tcp_reverse_example console
+```
+
+Then start a telnet session to port 5555:
+``` bash
+$ telnet localhost 5555
+```
+
+Type in a few words and see them reversed! Amazing!
+
+Be aware that there is a timeout of 5 seconds without receiving
+data before the example server disconnects your session.

--- a/examples/tcp_reverse/relx.config
+++ b/examples/tcp_reverse/relx.config
@@ -1,0 +1,2 @@
+{release, {tcp_reverse_example, "1"}, [tcp_reverse]}.
+{extended_start_script, true}.

--- a/examples/tcp_reverse/src/reverse_protocol.erl
+++ b/examples/tcp_reverse/src/reverse_protocol.erl
@@ -1,0 +1,61 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(reverse_protocol).
+
+-behaviour(gen_server).
+-behaviour(ranch_protocol).
+
+-export([start_link/4]).
+
+-export([init/1, init/4, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-export([reverse_binary/1]).
+
+-define(TIMEOUT, 5000).
+
+-record(state, {socket, transport}).
+
+reverse_binary(B) when is_binary(B) ->
+   [list_to_binary(
+       lists:reverse(
+           binary_to_list(binary:part(B, {0, byte_size(B)-2})))),
+    "\r\n"].
+
+start_link(Ref, Socket, Transport, Opts) ->
+    proc_lib:start_link(?MODULE, init, [Ref, Socket, Transport, Opts]).
+
+init(Args) ->
+    {ok, Args}.
+
+init(Ref, Socket, Transport, _Opts = []) ->
+    ok = proc_lib:init_ack({ok, self()}),
+    ok = ranch:accept_ack(Ref),
+    ok = Transport:setopts(Socket, [{active, once}]),
+    gen_server:enter_loop(?MODULE,[], {state, Socket, Transport},?TIMEOUT).
+
+handle_info({tcp, Socket, Data}, #state{transport = Transport} = State) ->
+    inet:setopts(State#state.socket, [{active, once}]),
+    Transport:send(Socket, reverse_binary(Data)),
+    {noreply, State, ?TIMEOUT};
+handle_info({tcp_closed, _Socket}, State) ->
+    {stop, normal, State};
+handle_info({tcp_error, _, Reason}, State) ->
+    {stop, Reason, State};
+handle_info(timeout, State) ->
+    {stop, normal, State};
+handle_info(_Info, State) ->
+    {stop, normal, State}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+

--- a/examples/tcp_reverse/src/tcp_reverse.app.src
+++ b/examples/tcp_reverse/src/tcp_reverse.app.src
@@ -1,0 +1,15 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+{application, tcp_reverse, [
+	{description, "Ranch TCP Reverse example."},
+	{vsn, "1"},
+	{modules, []},
+	{registered, [tcp_reverse_sup]},
+	{applications, [
+		kernel,
+		stdlib,
+		ranch
+	]},
+	{mod, {tcp_reverse_app, []}},
+	{env, []}
+]}.

--- a/examples/tcp_reverse/src/tcp_reverse.erl
+++ b/examples/tcp_reverse/src/tcp_reverse.erl
@@ -1,0 +1,13 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(tcp_reverse).
+
+%% API.
+-export([start/0]).
+
+%% API.
+
+start() ->
+    io:format("starting ranch and tcp_reverse~n"),
+	ok = application:start(ranch),
+	ok = application:start(tcp_reverse).

--- a/examples/tcp_reverse/src/tcp_reverse_app.erl
+++ b/examples/tcp_reverse/src/tcp_reverse_app.erl
@@ -1,0 +1,19 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @private
+-module(tcp_reverse_app).
+-behaviour(application).
+
+%% API.
+-export([start/2]).
+-export([stop/1]).
+
+%% API.
+
+start(_Type, _Args) ->
+    {ok, _} = ranch:start_listener(tcp_reverse, 10,
+				   ranch_tcp, [{port, 5555}], reverse_protocol, []),
+    tcp_reverse_sup:start_link().
+
+stop(_State) ->
+	ok.

--- a/examples/tcp_reverse/src/tcp_reverse_sup.erl
+++ b/examples/tcp_reverse/src/tcp_reverse_sup.erl
@@ -1,0 +1,22 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @private
+-module(tcp_reverse_sup).
+-behaviour(supervisor).
+
+%% API.
+-export([start_link/0]).
+
+%% supervisor.
+-export([init/1]).
+
+%% API.
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% supervisor.
+
+init([]) ->
+	{ok, {{one_for_one, 10, 10}, []}}.


### PR DESCRIPTION
Added a second example that uses a gen_server for the protocol implementation.
