### PR TITLE
Fix inherit listen options for accepted socket

### DIFF
--- a/test/check_tcp_options.erl
+++ b/test/check_tcp_options.erl
@@ -1,0 +1,15 @@
+-module(check_tcp_options).
+-behaviour(ranch_protocol).
+
+-export([start_link/4]).
+-export([init/3]).
+
+start_link(_, Socket, _, [{pid, TestPid}|TcpOptions]) ->
+	{ok, RealTcpOptions} =
+		inet:getopts(Socket, [Key || {Key, _} <- TcpOptions]),
+	Pid = spawn_link(?MODULE, init, [TestPid, RealTcpOptions, TcpOptions]),
+	{ok, Pid}.
+
+init(Pid, TcpOptions, TcpOptions) ->
+	Pid ! checked,
+	receive after 2500 -> ok end.


### PR DESCRIPTION
R16B03 for accumulete options for listen socket OTP use [inet:listen_options/2](https://github.com/erlang/otp/blob/maint/lib/kernel/src/inet.erl#L743) and it use last value in list. This make impossible set up in ranch own value for listen socket because default values added to the end of list .

Also [inet:listen_options/1](https://github.com/erlang/otp/blob/maint/lib/kernel/src/inet.erl#L736) has list of option allow for listen socket. May be we can expand current list in ranch? User may set up packet, send_timeout, send_timeout_close but ranch filter out it.
