### PR TITLE
Add support for {packet, N}

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -26,6 +26,7 @@
 -export([set_protocol_options/2]).
 -export([filter_options/3]).
 -export([set_option_default/3]).
+-export([set_option_defaults/2]).
 -export([require/1]).
 
 -type max_conns() :: non_neg_integer() | infinity.
@@ -149,6 +150,13 @@ set_option_default(Opts, Key, Value) ->
 		true -> Opts;
 		false -> [{Key, Value}|Opts]
 	end.
+
+-spec set_option_defaults(Opts, Opts)
+	-> Opts when Opts :: [{atom(), any()}].
+set_option_defaults(Opts, DefaultOpts) ->
+	lists:foldl(fun({Key, Val}, Acc) ->
+		ranch:set_option_default(Acc, Key, Val)
+	end, Opts, DefaultOpts).
 
 -spec require([atom()]) -> ok.
 require([]) ->

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -73,14 +73,14 @@ listen(Opts) ->
 	ranch:require([crypto, asn1, public_key, ssl]),
 	true = lists:keymember(cert, 1, Opts)
 		orelse lists:keymember(certfile, 1, Opts),
-	Opts2 = ranch:set_option_default(Opts, backlog, 1024),
-	Opts3 = ranch:set_option_default(Opts2, send_timeout, 30000),
-	Opts4 = ranch:set_option_default(Opts3, send_timeout_close, true),
-	Opts5 = ranch:set_option_default(Opts4, ciphers, unbroken_cipher_suites()),
+	Opts2 = ranch:set_option_defaults(Opts, [{backlog, 1024},
+	    {send_timeout, 30000},
+	    {send_timeout_close, true},
+	    {ciphers, unbroken_cipher_suites()}]),
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.
-	ssl:listen(0, ranch:filter_options(Opts5,
+	ssl:listen(0, ranch:filter_options(Opts2,
 		[backlog, cacertfile, cacerts, cert, certfile, ciphers,
 			fail_if_no_peer_cert, hibernate_after,
 			honor_cipher_order, ip, key, keyfile, linger,

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -51,16 +51,17 @@ messages() -> {tcp, tcp_closed, tcp_error}.
 
 -spec listen(opts()) -> {ok, inet:socket()} | {error, atom()}.
 listen(Opts) ->
-	Opts2 = ranch:set_option_default(Opts, backlog, 1024),
-	Opts3 = ranch:set_option_default(Opts2, send_timeout, 30000),
-	Opts4 = ranch:set_option_default(Opts3, send_timeout_close, true),
+	Opts2 = ranch:set_option_defaults(Opts, [{backlog, 1024},
+		{send_timeout, 30000},
+		{send_timeout_close, true},
+		{packet, raw}]),
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.
-	gen_tcp:listen(0, ranch:filter_options(Opts4,
-		[backlog, ip, linger, nodelay, port, raw,
+	gen_tcp:listen(0, ranch:filter_options(Opts2,
+		[backlog, ip, linger, nodelay, port, packet, raw,
 			send_timeout, send_timeout_close],
-		[binary, {active, false}, {packet, raw},
+		[binary, {active, false},
 			{reuseaddr, true}, {nodelay, true}])).
 
 -spec accept(inet:socket(), timeout())


### PR DESCRIPTION
- Add support for {packet, N} options
- add ranch:set_options_defaults/2 which updates option proplist
  with default values.

{packet, N} option does not work when I'm testing, so I dig into codes, and found that {packet, N} option is blocked by ranch_tcp protocol, so I removed {packet, raw} enforcement and add it to default options.
Another fix introduces ranch:set_option_defaults/2, which removes multiple ranch:set_options_default/3 calls to insert default options.

Maybe It's better to create new protocol based on ranch_tcp if there is some reason not allowing {packet, N}. Please let me know in that case.
