### PR TITLE
Don't report error on ssl {error, closed}

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -107,7 +107,7 @@ accept_ack(CSocket, Timeout) ->
 			ok = close(CSocket),
 			exit(normal);
 		%% Socket most likely stopped responding, don't error out.
-		{error, timeout} ->
+		{error, Reason} when Reason =:= timeout; Reason =:= closed ->
 			ok = close(CSocket),
 			exit(normal);
 		{error, Reason} ->


### PR DESCRIPTION
SSL socket might be closed on accept_ack, it happens quite often
and it is not a problem, so don't report error on the case.
