### PR TITLE
Add ranch_ssl:recv/2 and ranch_tcp:recv/2 with default timeout of infinity

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -22,6 +22,7 @@
 -export([accept_ack/2]).
 -export([connect/3]).
 -export([connect/4]).
+-export([recv/2]).
 -export([recv/3]).
 -export([send/2]).
 -export([sendfile/2]).
@@ -131,6 +132,11 @@ connect(Host, Port, Opts, Timeout) when is_integer(Port) ->
 	ssl:connect(Host, Port,
 		Opts ++ [binary, {active, false}, {packet, raw}],
 		Timeout).
+
+-spec recv(ssl:sslsocket(), non_neg_integer())
+	-> {ok, any()} | {error, closed | atom()}.
+recv(Socket, Length) ->
+	recv(Socket, Length, infinity).
 
 -spec recv(ssl:sslsocket(), non_neg_integer(), timeout())
 	-> {ok, any()} | {error, closed | atom()}.

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -22,6 +22,7 @@
 -export([accept_ack/2]).
 -export([connect/3]).
 -export([connect/4]).
+-export([recv/2]).
 -export([recv/3]).
 -export([send/2]).
 -export([sendfile/2]).
@@ -88,6 +89,11 @@ connect(Host, Port, Opts, Timeout) when is_integer(Port) ->
 	gen_tcp:connect(Host, Port,
 		Opts ++ [binary, {active, false}, {packet, raw}],
 		Timeout).
+
+-spec recv(inet:socket(), non_neg_integer())
+	-> {ok, any()} | {error, closed | atom()}.
+recv(Socket, Length) ->
+	recv(Socket, Length, timeout).
 
 -spec recv(inet:socket(), non_neg_integer(), timeout())
 	-> {ok, any()} | {error, closed | atom()}.


### PR DESCRIPTION
your documentation makes mention of `Transport:recv/2` but the functions don't exist in the included transports so I added them

I didn't add a callback requirement in `ranch_transport` because I think that would be a breaking change but it should probably be addressed
