### PR TITLE
Add SSL as dependency

### DIFF
--- a/src/ranch.app.src
+++ b/src/ranch.app.src
@@ -19,7 +19,8 @@
 	{registered, [ranch_sup, ranch_server]},
 	{applications, [
 		kernel,
-		stdlib
+		stdlib,
+		ssl
 	]},
 	{mod, {ranch_app, []}},
 	{env, []}


### PR DESCRIPTION
Without this dependency, the order of application stopping might be
wrong when using reltool. If SSL is stopped before ranch when ranch has
SSL listeners running, the application will crash and might cause the
entire 'application' server to hang, preventing VM shutdown.
