### PR TITLE
Fix ranch:start_listener/6 spec

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -35,7 +35,8 @@
 -export_type([ref/0]).
 
 -spec start_listener(ref(), non_neg_integer(), module(), any(), module(), any())
-	-> {ok, pid()} | {error, badarg}.
+	-> {ok, pid()} | {error, Reason}
+		when Reason :: badarg | {already_started, pid()} | already_present | term().
 start_listener(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts)
 		when is_integer(NbAcceptors) andalso is_atom(Transport)
 		andalso is_atom(Protocol) ->


### PR DESCRIPTION
Error reasons which may be returned by `supervisor:start_child/2` are added.

### Motivation

Currently dialyzer warns correct codes as below:

```erlang
-module(my_ranch).

-export([ensure_listener_started/6]).

%% @doc Equivalent to `ranch:start_listener/6' except it returns `{ok, pid()}' for already started listeners.
ensure_listener_started(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts) ->
    %% dialyzer warning:
    %%    The pattern {'error', {'already_started', Pid}} can never match the type {'error','badarg'} | {'ok',pid()}
    case ranch:start_listener(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts) of
        {error, {already_started, Pid}} -> {ok, Pid};
        Other                           -> Other
    end.
```