### PR TITLE
add missing max_connections tuple type to ranch_tcp/ssl:opts

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -57,6 +57,7 @@
 	| {port, inet:port_number()}
 	| {raw, non_neg_integer(), non_neg_integer(),
 		non_neg_integer() | binary()}
+	| {max_connections, non_neg_integer()}
 	| {reuse_session, fun()}
 	| {reuse_sessions, boolean()}
 	| {secure_renegotiate, boolean()}

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -42,6 +42,7 @@
 	| {port, inet:port_number()}
 	| {raw, non_neg_integer(), non_neg_integer(),
 		non_neg_integer() | binary()}
+	| {max_connections, non_neg_integer()}
 	| {send_timeout, timeout()}
 	| {send_timeout_close, boolean()}].
 -export_type([opts/0]).


### PR DESCRIPTION
`{max_connections, non_neg_integer()}` is a valid option but was left out from the opts type for `ranch_tcp` and `ranch_ssl`. This patch adds it, resolving dialyzer complaints if a call to `ranch:start_listener/6` includes `{max_connections, non_neg_integer()}` in the list of options.