### PR TITLE
This should *always report* the error instead of pattern-matching out...

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -109,14 +109,6 @@ accept_ack(CSocket, Timeout) ->
 	case ssl:ssl_accept(CSocket, Timeout) of
 		ok ->
 			ok;
-		%% Garbage was most likely sent to the socket, don't error out.
-		{error, {tls_alert, _}} ->
-			ok = close(CSocket),
-			exit(normal);
-		%% Socket most likely stopped responding, don't error out.
-		{error, Reason} when Reason =:= timeout; Reason =:= closed ->
-			ok = close(CSocket),
-			exit(normal);
 		{error, Reason} ->
 			ok = close(CSocket),
 			error(Reason)


### PR DESCRIPTION
..."some" common cases and calling `exit(normal)`.

`exit(normal)` wasted two days of my time because Cowboy is being used
in an embedded environment where things are a little slower and the
default timeout for the `ssl:ssl_accept/2` call was too aggressive and
was killing the socket before handshake could be completed giving an
arcane error from cURL (or many other clients) and no indication from
the node that there was indeed such a failure.
