### PR TITLE
Removing control options for ranch before invoking Transport:listen/1

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -28,8 +28,15 @@
 -export([set_option_default/3]).
 -export([require/1]).
 
--type max_conns() :: non_neg_integer() | infinity.
--export_type([max_conns/0]).
+-type max_conns() :: non_neg_integer() | 'infinity'.
+
+-type opts() :: [{max_connections, max_conns()}
+                 | {ack_timeout, timeout()}
+                 | {connection_type, 'worker' | 'supervisor'}
+                 | {shutdown, timeout() | 'brutal_kill'}
+                 | {socket, inet:socket()}].
+
+-export_type([max_conns/0, opts/0]).
 
 -type ref() :: any().
 -export_type([ref/0]).


### PR DESCRIPTION
Fixes #114