### PR TITLE
Improve reporting of SSL misconfiguration

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -74,7 +74,7 @@ start_listener(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts)
 				_ ->
 					ok
 			end,
-			Res
+			maybe_simplify_error(Res)
 	end.
 
 -spec stop_listener(ref()) -> ok | {error, not_found}.
@@ -194,3 +194,20 @@ require([App|Tail]) ->
 		{error, {already_started, App}} -> ok
 	end,
 	require(Tail).
+
+-spec simple_reason(term()) -> boolean().
+simple_reason(eaddrinuse) -> true;
+simple_reason(no_certificate_specified) -> true;
+simple_reason(_) -> false.
+
+-spec maybe_simplify_error(term()) -> term().
+maybe_simplify_error({error,
+					  {{shutdown,
+						{failed_to_start_child, ranch_acceptors_sup,
+						 {listen_error, _, Reason}}}, _}} = Error) ->
+	case simple_reason(Reason) of
+		true -> {error, Reason};
+		_ -> Error
+	end;
+maybe_simplify_error(Anything) ->
+	Anything.

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -52,5 +52,11 @@ init([Ref, NbAcceptors, Transport, TransOpts]) ->
 listen_error(Ref, Transport, TransOpts2, Reason) ->
 	error_logger:error_msg(
 		"Failed to start Ranch listener ~p in ~p:listen(~p) for reason ~p (~s)~n",
-		[Ref, Transport, TransOpts2, Reason, inet:format_error(Reason)]),
+		[Ref, Transport, TransOpts2, Reason, format_error(Reason)]),
 	exit({listen_error, Ref, Reason}).
+
+-spec format_error(atom()) -> string().
+format_error(no_certificate_specified) ->
+	"both 'cert' and 'certfile' options are missing";
+format_error(Reason) ->
+	inet:format_error(Reason).


### PR DESCRIPTION
Because `{badmatch,false}` below couldn't be explained without looking into
ranch source code.

```
   Error description:
   {could_not_start,rabbitmq_stomp,
       {{shutdown,
            {failed_to_start_child,'rabbit_stomp_listener_sup_:::61614',
                {shutdown,
                    {failed_to_start_child,
                        {ranch_listener_sup,
                            {acceptor,{0,0,0,0,0,0,0,0},61614}},
                        {shutdown,
                            {failed_to_start_child,ranch_acceptors_sup,
                                {{badmatch,false},
                                 [{ranch_ssl,listen,1,
                                      [{file,"src/ranch_ssl.erl"},{line,88}]},
                                  {ranch_acceptors_sup,init,1,
                                      [{file,"src/ranch_acceptors_sup.erl"},
                                       {line,35}]},
                                  {supervisor,init,1,
                                      [{file,"supervisor.erl"},{line,272}]},
                                  {gen_server,init_it,6,
                                      [{file,"gen_server.erl"},{line,328}]},
                                  {proc_lib,init_p_do_apply,3,
                                      [{file,"proc_lib.erl"},
                                       {line,240}]}]}}}}}}},
        {rabbit_stomp,start,[normal,[]]}}}
```
