### PR TITLE
Make values for the TLS 1.2 signature_algorithms extension configurable

### DIFF
--- a/doc/src/manual/ranch_ssl.asciidoc
+++ b/doc/src/manual/ranch_ssl.asciidoc
@@ -39,6 +39,7 @@ ssl_opt() = {alpn_preferred_protocols, [binary()]}
 	| {reuse_session, fun()}
 	| {reuse_sessions, boolean()}
 	| {secure_renegotiate, boolean()}
+	| {signature_algs, [{atom(), atom()}]}
 	| {sni_fun, fun()}
 	| {sni_hosts, [{string(), ssl_opt()}]}
 	| {user_lookup_fun, {fun(), any()}}
@@ -116,6 +117,8 @@ reuse_sessions (false)::
 	Whether to allow session reuse.
 secure_renegotiate (false)::
 	Whether to reject renegotiation attempts that do not conform to RFC5746.
+signature_algs::
+	The TLS signature algorithm extension may be used, from TLS 1.2, to negotiate which signature algorithm to use during the TLS handshake.
 sni_fun::
 	Function called when the client requests a host using Server Name Indication. Returns options to apply.
 sni_hosts::

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -61,6 +61,7 @@
 	| {reuse_session, fun()}
 	| {reuse_sessions, boolean()}
 	| {secure_renegotiate, boolean()}
+	| {signature_algs, [{atom(), atom()}]}
 	| {sni_fun, fun()}
 	| {sni_hosts, [{string(), ssl_opt()}]}
 	| {user_lookup_fun, {fun(), any()}}
@@ -105,7 +106,7 @@ listen_options() ->
 		dh, dhfile, fail_if_no_peer_cert, hibernate_after, honor_cipher_order,
 		key, keyfile, log_alert, next_protocols_advertised, partial_chain,
 		password, psk_identity, reuse_session, reuse_sessions, secure_renegotiate,
-		sni_fun, sni_hosts, user_lookup_fun, verify, verify_fun, versions
+		signature_algs, sni_fun, sni_hosts, user_lookup_fun, verify, verify_fun, versions
 		|ranch_tcp:listen_options()].
 
 -spec accept(ssl:sslsocket(), timeout())


### PR DESCRIPTION
Added in ssl-7.3.1 (OTP-13261). Documented in ssl-8.0.