### PR TITLE
adding more SSL configurable otions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/*/_rel
 examples/*/relx
 logs
 test/*.beam
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ examples/*/_rel
 examples/*/relx
 logs
 test/*.beam
-*.d

--- a/doc/src/manual/ranch_ssl.asciidoc
+++ b/doc/src/manual/ranch_ssl.asciidoc
@@ -15,6 +15,7 @@ The `ranch_ssl` module implements an SSL Ranch transport.
 [source,erlang]
 ----
 ssl_opt() = {alpn_preferred_protocols, [binary()]}
+	| {beast_mitigation, one_n_minus_one | zero_n | disabled}
 	| {cacertfile, string()}
 	| {cacerts, [public_key:der_encoded()]}
 	| {cert, public_key:der_encoded()}
@@ -65,8 +66,12 @@ or the `certfile` option. None of the other options are required.
 
 The default value is given next to the option name.
 
+alpn_advertised_protocols::
+	The protocols supported by the client to be sent to the server to be used for an ALPN
 alpn_preferred_protocols::
 	Perform Application-Layer Protocol Negotiation with the given list of preferred protocols.
+beast_mitigation::
+	Used to change the BEAST mitigation strategy to interoperate with legacy software.
 cacertfile::
 	Path to PEM encoded trusted certificates file used to verify peer certificates.
 cacerts::
@@ -105,6 +110,8 @@ next_protocols_advertised::
 	List of protocols to send to the client if it supports the Next Protocol extension.
 nodelay (true)::
 	Whether to enable TCP_NODELAY.
+padding_check::
+Affects TLS-1.0 connections only. If set to false, it disables the block cipher padding check to be able to interoperate with legacy software.
 partial_chain::
 	Claim an intermediate CA in the chain as trusted.
 password::
@@ -117,13 +124,19 @@ reuse_sessions (false)::
 	Whether to allow session reuse.
 secure_renegotiate (false)::
 	Whether to reject renegotiation attempts that do not conform to RFC5746.
+server_name_indication::
+	Can be specified when upgrading a TCP socket to a TLS socket to use the TLS Server Name Indication extension.
 signature_algs::
 	The TLS signature algorithm extension may be used, from TLS 1.2, to negotiate which signature algorithm to use during the TLS handshake.
 sni_fun::
 	Function called when the client requests a host using Server Name Indication. Returns options to apply.
 sni_hosts::
 	Options to apply for the host that matches what the client requested with Server Name Indication.
+srp_identity::
+	Specifies the username and password to use to authenticate to the server.
 user_lookup_fun::
+v2_hello_compatible::
+The server accepts clients that send hello messages on SSL-2.0 format but offers supported SSL/TLS versions.
 	Function called to determine the shared secret when using PSK, or provide parameters when using SRP.
 verify (verify_none)::
 	Use `verify_peer` to request a certificate from the client.

--- a/doc/src/manual/ranch_ssl.asciidoc
+++ b/doc/src/manual/ranch_ssl.asciidoc
@@ -34,6 +34,7 @@ ssl_opt() = {alpn_preferred_protocols, [binary()]}
 	| {keyfile, string()}
 	| {log_alert, boolean()}
 	| {next_protocols_advertised, [binary()]}
+	| {padding_check, boolean()}
 	| {partial_chain, fun(([public_key:der_encoded()]) -> {trusted_ca, public_key:der_encoded()} | unknown_ca)}
 	| {password, string()}
 	| {psk_identity, string()}
@@ -44,6 +45,7 @@ ssl_opt() = {alpn_preferred_protocols, [binary()]}
 	| {sni_fun, fun()}
 	| {sni_hosts, [{string(), ssl_opt()}]}
 	| {user_lookup_fun, {fun(), any()}}
+	| {v2_hello_compatible, boolean()}
 	| {verify, ssl:verify_type()}
 	| {verify_fun, {fun(), any()}}
 	| {versions, [atom()]}.
@@ -66,8 +68,6 @@ or the `certfile` option. None of the other options are required.
 
 The default value is given next to the option name.
 
-alpn_advertised_protocols::
-	The protocols supported by the client to be sent to the server to be used for an ALPN
 alpn_preferred_protocols::
 	Perform Application-Layer Protocol Negotiation with the given list of preferred protocols.
 beast_mitigation::
@@ -124,16 +124,12 @@ reuse_sessions (false)::
 	Whether to allow session reuse.
 secure_renegotiate (false)::
 	Whether to reject renegotiation attempts that do not conform to RFC5746.
-server_name_indication::
-	Can be specified when upgrading a TCP socket to a TLS socket to use the TLS Server Name Indication extension.
 signature_algs::
 	The TLS signature algorithm extension may be used, from TLS 1.2, to negotiate which signature algorithm to use during the TLS handshake.
 sni_fun::
 	Function called when the client requests a host using Server Name Indication. Returns options to apply.
 sni_hosts::
 	Options to apply for the host that matches what the client requested with Server Name Indication.
-srp_identity::
-	Specifies the username and password to use to authenticate to the server.
 user_lookup_fun::
 v2_hello_compatible::
 The server accepts clients that send hello messages on SSL-2.0 format but offers supported SSL/TLS versions.

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -36,8 +36,7 @@
 -export([shutdown/2]).
 -export([close/1]).
 
--type ssl_opt() :: {alpn_advertised_protocols, [binary()]}
-	| {alpn_preferred_protocols, [binary()]}
+-type ssl_opt() :: {alpn_preferred_protocols, [binary()]}
 	| {beast_mitigation, one_n_minus_one | zero_n | disabled}
 	| {cacertfile, string()}
 	| {cacerts, [public_key:der_encoded()]}
@@ -65,11 +64,9 @@
 	| {reuse_session, fun()}
 	| {reuse_sessions, boolean()}
 	| {secure_renegotiate, boolean()}
-	| {server_name_indication, string()}
 	| {signature_algs, [{atom(), atom()}]}
 	| {sni_fun, fun()}
 	| {sni_hosts, [{string(), ssl_opt()}]}
-	| {srp_identity, [{Username :: string(), Password :: string()}]}
 	| {user_lookup_fun, {fun(), any()}}
 	| {v2_hello_compatible, boolean()}
 	| {verify, ssl:verify_type()}
@@ -108,14 +105,12 @@ listen(Opts) ->
 			{reuseaddr, true}, {nodelay, true}])).
 
 listen_options() ->
-	[alpn_advertised_protocols, alpn_preferred_protocols, beast_mitigation,
-		cacertfile, cacerts, cert, certfile, ciphers, client_renegotiation,
-		crl_cache, crl_check, depth, dh, dhfile, fallback, fail_if_no_peer_cert,
-		hibernate_after, honor_cipher_order, key, keyfile, log_alert,
-		next_protocols_advertised, partial_chain, password, padding_check,
-		psk_identity, reuse_session, reuse_sessions, secure_renegotiate,
-		server_name_indication, signature_algs, sni_fun, sni_hosts, srp_identity,
-		user_lookup_fun, v2_hello_compatible, verify, verify_fun, versions
+	[alpn_preferred_protocols, beast_mitigation, cacertfile, cacerts, cert, certfile,
+	 	ciphers, client_renegotiation, crl_cache, crl_check, depth, dh, dhfile,
+	 	fallback, fail_if_no_peer_cert, hibernate_after, honor_cipher_order, key,
+	 	keyfile, log_alert, next_protocols_advertised, partial_chain, password, padding_check,
+		psk_identity, reuse_session, reuse_sessions, secure_renegotiate, signature_algs,
+	 	sni_fun, sni_hosts, user_lookup_fun, v2_hello_compatible, verify, verify_fun, versions
 		|ranch_tcp:listen_options()].
 
 -spec accept(ssl:sslsocket(), timeout())

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -49,7 +49,6 @@
 	| {depth, 0..255}
 	| {dh, public_key:der_encoded()}
 	| {dhfile, string()}
-	| {fallback, boolean()}
 	| {fail_if_no_peer_cert, boolean()}
 	| {hibernate_after, integer() | undefined}
 	| {honor_cipher_order, boolean()}
@@ -107,8 +106,8 @@ listen(Opts) ->
 listen_options() ->
 	[alpn_preferred_protocols, beast_mitigation, cacertfile, cacerts, cert, certfile,
 	 	ciphers, client_renegotiation, crl_cache, crl_check, depth, dh, dhfile,
-	 	fallback, fail_if_no_peer_cert, hibernate_after, honor_cipher_order, key,
-	 	keyfile, log_alert, next_protocols_advertised, partial_chain, password, padding_check,
+		fail_if_no_peer_cert, hibernate_after, honor_cipher_order, key, keyfile,
+	 	log_alert, next_protocols_advertised, partial_chain, password, padding_check,
 		psk_identity, reuse_session, reuse_sessions, secure_renegotiate, signature_algs,
 	 	sni_fun, sni_hosts, user_lookup_fun, v2_hello_compatible, verify, verify_fun, versions
 		|ranch_tcp:listen_options()].

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -36,7 +36,9 @@
 -export([shutdown/2]).
 -export([close/1]).
 
--type ssl_opt() :: {alpn_preferred_protocols, [binary()]}
+-type ssl_opt() :: {alpn_advertised_protocols, [binary()]}
+	| {alpn_preferred_protocols, [binary()]}
+	| {beast_mitigation, one_n_minus_one | zero_n | disabled}
 	| {cacertfile, string()}
 	| {cacerts, [public_key:der_encoded()]}
 	| {cert, public_key:der_encoded()}
@@ -48,6 +50,7 @@
 	| {depth, 0..255}
 	| {dh, public_key:der_encoded()}
 	| {dhfile, string()}
+	| {fallback, boolean()}
 	| {fail_if_no_peer_cert, boolean()}
 	| {hibernate_after, integer() | undefined}
 	| {honor_cipher_order, boolean()}
@@ -55,16 +58,20 @@
 	| {keyfile, string()}
 	| {log_alert, boolean()}
 	| {next_protocols_advertised, [binary()]}
+	| {padding_check, boolean()}
 	| {partial_chain, fun(([public_key:der_encoded()]) -> {trusted_ca, public_key:der_encoded()} | unknown_ca)}
 	| {password, string()}
 	| {psk_identity, string()}
 	| {reuse_session, fun()}
 	| {reuse_sessions, boolean()}
 	| {secure_renegotiate, boolean()}
+	| {server_name_indication, string()}
 	| {signature_algs, [{atom(), atom()}]}
 	| {sni_fun, fun()}
 	| {sni_hosts, [{string(), ssl_opt()}]}
+	| {srp_identity, [{Username :: string(), Password :: string()}]}
 	| {user_lookup_fun, {fun(), any()}}
+	| {v2_hello_compatible, boolean()}
 	| {verify, ssl:verify_type()}
 	| {verify_fun, {fun(), any()}}
 	| {versions, [atom()]}.
@@ -101,12 +108,14 @@ listen(Opts) ->
 			{reuseaddr, true}, {nodelay, true}])).
 
 listen_options() ->
-	[alpn_preferred_protocols, cacertfile, cacerts, cert, certfile,
-		ciphers, client_renegotiation, crl_cache, crl_check, depth,
-		dh, dhfile, fail_if_no_peer_cert, hibernate_after, honor_cipher_order,
-		key, keyfile, log_alert, next_protocols_advertised, partial_chain,
-		password, psk_identity, reuse_session, reuse_sessions, secure_renegotiate,
-		signature_algs, sni_fun, sni_hosts, user_lookup_fun, verify, verify_fun, versions
+	[alpn_advertised_protocols, alpn_preferred_protocols, beast_mitigation,
+		cacertfile, cacerts, cert, certfile, ciphers, client_renegotiation,
+		crl_cache, crl_check, depth, dh, dhfile, fallback, fail_if_no_peer_cert,
+		hibernate_after, honor_cipher_order, key, keyfile, log_alert,
+		next_protocols_advertised, partial_chain, password, padding_check,
+		psk_identity, reuse_session, reuse_sessions, secure_renegotiate,
+		server_name_indication, signature_algs, sni_fun, sni_hosts, srp_identity,
+		user_lookup_fun, v2_hello_compatible, verify, verify_fun, versions
 		|ranch_tcp:listen_options()].
 
 -spec accept(ssl:sslsocket(), timeout())


### PR DESCRIPTION
Providing more configurable options for SSL. This will help and give more control to frameworks like Phoenix for future development, and not rely on the default values from Erlang.
