### PR TITLE
Format eacces errors in a more readable way

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -84,8 +84,9 @@ maybe_started({error, {{shutdown,
 maybe_started(Res) ->
 	Res.
 
-start_error(E=eaddrinuse, _) -> {error, E};
-start_error(E=no_cert, _) -> {error, E};
+start_error(E = eaddrinuse, _) -> {error, E};
+start_error(E = eacces, _) -> {error, E};
+start_error(E = no_cert, _) -> {error, E};
 start_error(_, Error) -> Error.
 
 -spec stop_listener(ref()) -> ok | {error, not_found}.

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -57,6 +57,8 @@ listen_error(Ref, Transport, TransOpts0, Reason) ->
 		[Ref, Transport, TransOpts, Reason, format_error(Reason)]),
 	exit({listen_error, Ref, Reason}).
 
+format_error(eaccess) ->
+	"permission denied; insufficient privileges to bind to the port";
 format_error(no_cert) ->
 	"no certificate provided; see cert, certfile, sni_fun or sni_hosts options";
 format_error(Reason) ->

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -58,7 +58,7 @@ listen_error(Ref, Transport, TransOpts0, Reason) ->
 	exit({listen_error, Ref, Reason}).
 
 format_error(eaccess) ->
-	"permission denied; insufficient privileges to bind to the port";
+	"permission denied; insufficient privileges, cannot bind to a port";
 format_error(no_cert) ->
 	"no certificate provided; see cert, certfile, sni_fun or sni_hosts options";
 format_error(Reason) ->

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -36,7 +36,8 @@ groups() ->
 		tcp_set_max_connections,
 		tcp_set_max_connections_clean,
 		tcp_upgrade,
-		tcp_error_eaddrinuse
+		tcp_error_eaddrinuse,
+                tcp_error_eacces
 	]}, {ssl, [
 		ssl_accept_error,
 		ssl_accept_socket,
@@ -45,7 +46,8 @@ groups() ->
 		ssl_sni_echo,
 		ssl_sni_fail,
 		ssl_error_eaddrinuse,
-		ssl_error_no_cert
+		ssl_error_no_cert,
+                ssl_error_eacces
 	]}, {misc, [
 		misc_bad_transport,
 		misc_bad_transport_options,
@@ -258,7 +260,7 @@ do_ssl_sni_fail() ->
 	ok.
 
 ssl_error_eaddrinuse(_) ->
-	doc("Check that eaddrinuse returns a simplified error."),
+	doc("Ensure that failure due to an eaddrinuse returns a compact readable error."),
 	Name = name(),
 	Opts = ct_helper:get_certs_from_ets(),
 	{ok, _} = ranch:start_listener(Name, 1, ranch_ssl, Opts, active_echo_protocol, []),
@@ -271,8 +273,16 @@ ssl_error_eaddrinuse(_) ->
 	ok.
 
 ssl_error_no_cert(_) ->
-	doc("Check that missing certificate returns a simplified error."),
+	doc("Ensure that failure due to missing certificate returns a compact readable error."),
 	{error, no_cert} = ranch:start_listener(name(), 1, ranch_ssl, [], active_echo_protocol, []),
+	ok.
+
+ssl_error_eacces(_) ->
+        doc("Ensure that failure due to an eacces returns a compact readable error."),
+        Name = name(),
+        Opts = ct_helper:get_certs_from_ets(),
+	{error, eacces} = ranch:start_listener(Name, 1,
+                ranch_ssl, [{port, 283}|Opts], active_echo_protocol, []),
 	ok.
 
 %% tcp.
@@ -461,7 +471,7 @@ tcp_upgrade(_) ->
 	ok = ranch:stop_listener(Name).
 
 tcp_error_eaddrinuse(_) ->
-	doc("Check that eaddrinuse returns a simplified error."),
+	doc("Ensure that failure due to an eaddrinuse returns a compact readable error."),
 	Name = name(),
 	{ok, _} = ranch:start_listener(Name, 1, ranch_tcp, [], active_echo_protocol, []),
 	Port = ranch:get_port(Name),
@@ -471,6 +481,14 @@ tcp_error_eaddrinuse(_) ->
 	%% Make sure the listener stopped.
 	{'EXIT', _} = begin catch ranch:get_port(Name) end,
 	ok.
+
+tcp_error_eacces(_) ->
+        doc("Ensure that failure due to an eacces returns a compact readable error."),
+        Name = name(),
+	{error, eacces} = ranch:start_listener(Name, 1,
+                ranch_tcp, [{port, 283}], active_echo_protocol, []),
+	ok.
+
 
 %% Supervisor tests
 


### PR DESCRIPTION
This is a follow-up to the improvements contributed by @binarin in https://github.com/ninenines/ranch/commit/f33ff7cbacb204adae9d53ad15829f44c4140525.

Per discussion in https://github.com/rabbitmq/rabbitmq-server/issues/1088.