### PR TITLE
Ensure listener restart with changed TransOpts

### DIFF
--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -18,7 +18,7 @@
 -module(ranch_conns_sup).
 
 %% API.
--export([start_link/6]).
+-export([start_link/3]).
 -export([start_protocol/2]).
 -export([active_connections/1]).
 
@@ -45,9 +45,12 @@
 
 %% API.
 
--spec start_link(ranch:ref(), conn_type(), shutdown(), module(),
-	timeout(), module()) -> {ok, pid()}.
-start_link(Ref, ConnType, Shutdown, Transport, AckTimeout, Protocol) ->
+-spec start_link(ranch:ref(), module(), module()) -> {ok, pid()}.
+start_link(Ref, Transport, Protocol) ->
+	TransOpts = ranch_server:get_transport_options(Ref),
+	ConnType = proplists:get_value(connection_type, TransOpts, worker),
+	Shutdown = proplists:get_value(shutdown, TransOpts, 5000),
+	AckTimeout = proplists:get_value(ack_timeout, TransOpts, 5000),
 	proc_lib:start_link(?MODULE, init,
 		[self(), Ref, ConnType, Shutdown, Transport, AckTimeout, Protocol]).
 

--- a/src/ranch_listener_sup.erl
+++ b/src/ranch_listener_sup.erl
@@ -25,17 +25,14 @@ start_link(Ref, NumAcceptors, Transport, TransOpts, Protocol, ProtoOpts) ->
 	ranch_server:set_new_listener_opts(Ref, MaxConns, TransOpts, ProtoOpts,
 		[Ref, NumAcceptors, Transport, TransOpts, Protocol, ProtoOpts]),
 	supervisor:start_link(?MODULE, {
-		Ref, NumAcceptors, Transport, TransOpts, Protocol
+		Ref, NumAcceptors, Transport, Protocol
 	}).
 
-init({Ref, NumAcceptors, Transport, TransOpts, Protocol}) ->
+init({Ref, NumAcceptors, Transport, Protocol}) ->
 	ok = ranch_server:set_listener_sup(Ref, self()),
-	AckTimeout = proplists:get_value(ack_timeout, TransOpts, 5000),
-	ConnType = proplists:get_value(connection_type, TransOpts, worker),
-	Shutdown = proplists:get_value(shutdown, TransOpts, 5000),
 	ChildSpecs = [
 		{ranch_conns_sup, {ranch_conns_sup, start_link,
-				[Ref, ConnType, Shutdown, Transport, AckTimeout, Protocol]},
+				[Ref, Transport, Protocol]},
 			permanent, infinity, supervisor, [ranch_conns_sup]},
 		{ranch_acceptors_sup, {ranch_acceptors_sup, start_link,
 				[Ref, NumAcceptors, Transport]},

--- a/src/ranch_server.erl
+++ b/src/ranch_server.erl
@@ -156,10 +156,10 @@ init([]) ->
 	{ok, #state{monitors=ConnMonitors++ListenerMonitors}}.
 
 handle_call({set_new_listener_opts, Ref, MaxConns, TransOpts, ProtoOpts, StartArgs}, _, State) ->
-	ets:insert(?TAB, {{max_conns, Ref}, MaxConns}),
-	ets:insert(?TAB, {{trans_opts, Ref}, TransOpts}),
-	ets:insert(?TAB, {{proto_opts, Ref}, ProtoOpts}),
-	ets:insert(?TAB, {{listener_start_args, Ref}, StartArgs}),
+	ets:insert_new(?TAB, {{max_conns, Ref}, MaxConns}),
+	ets:insert_new(?TAB, {{trans_opts, Ref}, TransOpts}),
+	ets:insert_new(?TAB, {{proto_opts, Ref}, ProtoOpts}),
+	ets:insert_new(?TAB, {{listener_start_args, Ref}, StartArgs}),
 	{reply, ok, State};
 handle_call({set_connections_sup, Ref, Pid}, _,
 		State=#state{monitors=Monitors}) ->


### PR DESCRIPTION
* transport options are not overwritten if they exist in `ranch_server` already
* retrieval of transport options is pushed down from `ranch_listener_sup` to `ranch_conns_sup`
* whether retrieval of options in `ranch_conns_sup` should happen in `start_link` or in `init`is up for debate