### PR TITLE
get_status/1 should report running when acceptors_sup is restarting

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -270,7 +270,7 @@ get_status(Ref) ->
 	case lists:keyfind(ranch_acceptors_sup, 1, Children) of
 		{_, undefined, _, _} ->
 			suspended;
-		{_, AcceptorsSup, _, _} when is_pid(AcceptorsSup) ->
+		{_, _, _, _} ->
 			running
 	end.
 


### PR DESCRIPTION
`get_status/1` would crash the caller when the `acceptors_sup` of the requested listener was in the process of restarting (recovering from crash) the moment the call was made. instead, it should report `running` since the listener itself is actually running.