### PR TITLE
minor corrections to ranch_app documentation

### DIFF
--- a/doc/src/manual/ranch_app.asciidoc
+++ b/doc/src/manual/ranch_app.asciidoc
@@ -22,8 +22,8 @@ Functions:
 
 Transports:
 
-* link:man:ranch_ssl(3)[ranch_ssl(3)] - SSL transport
-* link:man:ranch_tcp(3)[ranch_tcp(3)] - TLS transport
+* link:man:ranch_ssl(3)[ranch_ssl(3)] - SSL/TLS transport
+* link:man:ranch_tcp(3)[ranch_tcp(3)] - TCP transport
 
 Behaviors:
 

--- a/doc/src/manual/ranch_app.asciidoc
+++ b/doc/src/manual/ranch_app.asciidoc
@@ -44,8 +44,8 @@ application. To start Ranch and all dependencies at once:
 
 == Environment
 
-The `ranch` application defines three application environment
-configuration parameters.
+The `ranch` application defines one application environment
+configuration parameter.
 
 profile (false)::
 
@@ -54,14 +54,6 @@ When enabled, Ranch will start `eprof` profiling automatically.
 You can use the `ranch_app:profile_output/0` function to stop
 profiling and output the results to the files 'procs.profile'
 and 'total.profile'. Do not use in production.
-
-ranch_sup_intensity (1)::
-
-Restart intensity for the ranch_server process.
-
-ranch_sup_period (5)::
-
-Restart period, in seconds, for the ranch_server process.
 
 == See also
 


### PR DESCRIPTION
I noticed that the documentation for ranch_tcp said that in handled TLS transport instead of handling the TCP transport.  Also ranch_ssl handles both SSL and TLS.

Since you mention the profile environment variable, I thought that ranch_sup_intensity and ranch_sup_period should also be mentioned.