### PR TITLE
fix inconsistent naming of second parameter of filter_user_options/2

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -421,12 +421,12 @@ filter_user_options([Opt = {Key, _}|Tail], DisallowedKeys) ->
 			filter_user_options(Tail, DisallowedKeys)
 	end;
 %% Special option forms.
-filter_user_options([inet|Tail], AllowedKeys) ->
-	[inet|filter_user_options(Tail, AllowedKeys)];
-filter_user_options([inet6|Tail], AllowedKeys) ->
-	[inet6|filter_user_options(Tail, AllowedKeys)];
-filter_user_options([Opt = {raw, _, _, _}|Tail], AllowedKeys) ->
-	[Opt|filter_user_options(Tail, AllowedKeys)];
+filter_user_options([inet|Tail], DisallowedKeys) ->
+	[inet|filter_user_options(Tail, DisallowedKeys)];
+filter_user_options([inet6|Tail], DisallowedKeys) ->
+	[inet6|filter_user_options(Tail, DisallowedKeys)];
+filter_user_options([Opt = {raw, _, _, _}|Tail], DisallowedKeys) ->
+	[Opt|filter_user_options(Tail, DisallowedKeys)];
 filter_user_options([Opt|Tail], DisallowedKeys) ->
 	filter_options_warning(Opt),
 	filter_user_options(Tail, DisallowedKeys);


### PR DESCRIPTION
I noticed some inconsistent naming of the second parameter in some clauses of filter_user_options/2.  Normally I don't have a problem with this but the name AllowedKeys implies the exact opposite of what the variable is bound to.