### PR TITLE
fix remove connections

### DIFF
--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -145,7 +145,7 @@ loop(State=#state{parent=Parent, ref=Ref, conn_type=ConnType,
 			case put(Pid, removed) of
 				active ->
 					loop(State, CurConns - 1, NbChildren, Sleepers);
-				remove ->
+				removed ->
 					loop(State, CurConns, NbChildren, Sleepers);
 				undefined ->
 					_ = erase(Pid),

--- a/test/remove_conn_and_wait_protocol.erl
+++ b/test/remove_conn_and_wait_protocol.erl
@@ -10,10 +10,12 @@ start_link(Ref, _, _, [{remove, MaybeRemove, Timeout}]) ->
 
 init(Ref, MaybeRemove, Timeout) ->
 	{ok, _} = ranch:handshake(Ref),
-	case MaybeRemove of
+	_ = case MaybeRemove of
 		true ->
 			ranch:remove_connection(Ref);
 		false ->
-			ok
+			ok;
+		N ->
+			[ranch:remove_connection(Ref) || _ <- lists:seq(1, N)]
 	end,
 	receive after Timeout -> ok end.


### PR DESCRIPTION
Due to a typo, repeated calls to ranch:remove_connection from a worker process would crash the respective ranch_conns_sup.