### PR TITLE
Fix warning on `ssl_cipher:erl_cipher_suite/0' type

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -51,7 +51,7 @@
 	| {cacerts, [public_key:der_encoded()]}
 	| {cert, public_key:der_encoded()}
 	| {certfile, string()}
-	| {ciphers, [ssl_cipher:erl_cipher_suite()]}
+	| {ciphers, [ssl:erl_cipher_suite()]}
 	| {client_renegotiation, boolean()}
 	| {crl_cache, {module(), {internal | any(), list()}}}
 	| {crl_check, boolean() | peer | best_effort}


### PR DESCRIPTION
As reported in [issue #218](https://github.com/ninenines/ranch/issues/218).

* Up until OTP 21.0 it was defined on the [ssl_cipher](https://github.com/erlang/otp/blob/OTP-21.0/lib/ssl/src/ssl_cipher.erl#L56-L60) module
* On OTP 21.1 it was moved into [ssl_cipher_format](https://github.com/erlang/otp/blob/OTP-21.1/lib/ssl/src/ssl_cipher_format.erl#L40-L44)
* On OTP 21.3 it was moved into [ssl](https://github.com/erlang/otp/blob/OTP-21.3/lib/ssl/src/ssl.erl#L136-L140)

Fix the issue by using OTP 21.3's definition to the detriment of previous ones. 

Thanks for watching this season of "Where's Waldo"! 