### PR TITLE
Allow configurable number of connection supervisors

### DIFF
--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -182,9 +182,9 @@ socket and that it is operational.
 === Limiting the number of concurrent connections
 
 The `max_connections` transport option allows you to limit the number
-of concurrent connections. It defaults to 1024. Its purpose is to
-prevent your system from being overloaded and ensuring all the
-connections are handled optimally.
+of concurrent connections per connection supervisor (see below).
+It defaults to 1024. Its purpose is to prevent your system from being
+overloaded and ensuring all the connections are handled optimally.
 
 .Customizing the maximum number of concurrent connections
 
@@ -258,6 +258,25 @@ measure to find the best value for your application.
 [source,erlang]
 {ok, _} = ranch:start_listener(tcp_echo,
 	ranch_tcp, [{port, 5555}, {num_acceptors, 42}],
+	echo_protocol, []
+).
+
+=== Customizing the number of connection supervisors
+
+By default Ranch will use one connection supervisor for each
+acceptor process (but not vice versa). Their task is to
+supervise the connection processes started by an acceptor.
+
+Note that the association between the individual acceptors and
+connection supervisors is fixed, meaning that connection
+processes started by an individual acceptor will always be
+hosted by the same connection supervisor.
+
+.Specifying a custom number of connection supervisors
+
+[source,erlang]
+{ok, _} = ranch:start_listener(tcp_echo,
+	ranch_tcp, #{socket_opts => [{port, 5555}], num_conns_sups => 42}],
 	echo_protocol, []
 ).
 

--- a/doc/src/manual/ranch.asciidoc
+++ b/doc/src/manual/ranch.asciidoc
@@ -32,10 +32,10 @@ Connections:
 
 Options:
 
-* link:man:ranch:get_max_connections(3)[ranch:get_max_connections(3)] - Get the max number of connections
+* link:man:ranch:get_max_connections(3)[ranch:get_max_connections(3)] - Get the max number of connections per connection supervisor
 * link:man:ranch:get_protocol_options(3)[ranch:get_protocol_options(3)] - Get the current protocol options
 * link:man:ranch:get_transport_options(3)[ranch:get_transport_options(3)] - Get the current transport options
-* link:man:ranch:set_max_connections(3)[ranch:set_max_connections(3)] - Set the max number of connections
+* link:man:ranch:set_max_connections(3)[ranch:set_max_connections(3)] - Set the max number of connections per connection supervisor
 * link:man:ranch:set_protocol_options(3)[ranch:set_protocol_options(3)] - Set the protocol options
 * link:man:ranch:set_transport_options(3)[ranch:set_transport_options(3)] - Set the transport options
 
@@ -56,7 +56,7 @@ Introspection:
 max_conns() = non_neg_integer() | infinity
 ----
 
-Maximum number of connections allowed on this listener.
+Maximum number of connections allowed per connection supervisor.
 
 This is a soft limit. The actual number of connections
 might be slightly above the limit due to concurrency
@@ -91,6 +91,7 @@ opts() = any() | #{
     max_connections   => max_conns(),
     logger            => module(),
     num_acceptors     => pos_integer(),
+    num_conns_sups    => pos_integer(),
     shutdown          => timeout() | brutal_kill,
     socket_opts       => any()
 }
@@ -122,12 +123,17 @@ Maximum allowed time for the `ranch:handshake/1,2` call to finish.
 
 max_connections (1024)::
 
-Maximum number of active connections. Soft limit.
-Use `infinity` to disable the limit entirely.
+Maximum number of active connections per connection supervisor.
+Soft limit. Use `infinity` to disable the limit entirely.
 
 num_acceptors (10)::
 
 Number of processes that accept connections.
+
+num_conns_sups (see below)::
+
+Number of processes that supervise connection processes.
+If not specified, defaults to be equal to `num_acceptors`.
 
 shutdown (5000)::
 

--- a/doc/src/manual/ranch.get_max_connections.asciidoc
+++ b/doc/src/manual/ranch.get_max_connections.asciidoc
@@ -2,7 +2,7 @@
 
 == Name
 
-ranch:get_max_connections - Get the max number of connections
+ranch:get_max_connections - Get the max number of connections per connection supervisor
 
 == Description
 
@@ -12,7 +12,7 @@ get_max_connections(Ref :: ranch:ref())
     -> MaxConns :: ranch:max_conns()
 ----
 
-Get the max number of connections.
+Get the max number of connections per connection supervisor.
 
 == Arguments
 
@@ -22,11 +22,12 @@ The listener name.
 
 == Return value
 
-The maximum number of connections is returned.
+The maximum number of connections per connection supervisor
+is returned.
 
 == Examples
 
-.Get the max number of connections
+.Get the max number of connections per connection supervisor
 [source,erlang]
 ----
 MaxConns = ranch:get_max_connections(example).

--- a/doc/src/manual/ranch.info.asciidoc
+++ b/doc/src/manual/ranch.info.asciidoc
@@ -32,7 +32,7 @@ status:: Listener status, either running or suspended.
 ip:: Interface Ranch listens on.
 port:: Port number Ranch listens on.
 num_acceptors:: Number of acceptor processes.
-max_connections:: Maximum number of connections.
+max_connections:: Maximum number of connections per connection supervisor.
 active_connections:: Number of active connections.
 all_connections:: Number of connections, including those removed from the count.
 transport:: Transport module.

--- a/doc/src/manual/ranch.set_max_connections.asciidoc
+++ b/doc/src/manual/ranch.set_max_connections.asciidoc
@@ -2,7 +2,7 @@
 
 == Name
 
-ranch:set_max_connections - Set the max number of connections
+ranch:set_max_connections - Set the max number of connections per connection supervisor
 
 == Description
 
@@ -13,7 +13,7 @@ set_max_connections(Ref      :: ranch:ref(),
     -> ok
 ----
 
-Set the max number of connections.
+Set the max number of connections per connection supervisor.
 
 The change will be applied immediately. If the new value is
 smaller than the previous one, Ranch will wait for the extra
@@ -28,7 +28,7 @@ The listener name.
 
 MaxConns::
 
-The new maximum number of connections.
+The new maximum number of connections per connection supervisor.
 
 == Return value
 
@@ -36,7 +36,7 @@ The atom `ok` is always returned. It can be safely ignored.
 
 == Examples
 
-.Set the max number of connections
+.Set the max number of connections per connection supervisor
 [source,erlang]
 ----
 ranch:set_max_connections(example, 10000).

--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -65,6 +65,7 @@
 	max_connections => max_conns(),
 	logger => module(),
 	num_acceptors => pos_integer(),
+	num_conns_sups => pos_integer(),
 	shutdown => timeout() | brutal_kill,
 	socket_opts => any()
 }.
@@ -113,7 +114,7 @@ normalize_opts(List0) when is_list(List0) ->
 			false ->
 				{Map2, List2}
 		end
-	end, {Map1, List1}, [connection_type, max_connections, num_acceptors, shutdown]),
+	end, {Map1, List1}, [connection_type, max_connections, num_acceptors, num_conns_sups, shutdown]),
 	if
 		Map =:= #{} ->
 			ok;

--- a/src/ranch_acceptor.erl
+++ b/src/ranch_acceptor.erl
@@ -14,12 +14,13 @@
 
 -module(ranch_acceptor).
 
--export([start_link/4]).
+-export([start_link/5]).
 -export([loop/5]).
 
--spec start_link(inet:socket(), module(), module(), pid())
+-spec start_link(ranch:ref(), non_neg_integer(), inet:socket(), module(), module())
 	-> {ok, pid()}.
-start_link(LSocket, Transport, Logger, ConnsSup) ->
+start_link(Ref, AcceptorId, LSocket, Transport, Logger) ->
+	ConnsSup = ranch_server:get_connections_sup(Ref, AcceptorId),
 	MonitorRef = monitor(process, ConnsSup),
 	Pid = spawn_link(?MODULE, loop, [LSocket, Transport, Logger, ConnsSup, MonitorRef]),
 	{ok, Pid}.

--- a/src/ranch_acceptor.erl
+++ b/src/ranch_acceptor.erl
@@ -17,7 +17,7 @@
 -export([start_link/5]).
 -export([loop/5]).
 
--spec start_link(ranch:ref(), non_neg_integer(), inet:socket(), module(), module())
+-spec start_link(ranch:ref(), pos_integer(), inet:socket(), module(), module())
 	-> {ok, pid()}.
 start_link(Ref, AcceptorId, LSocket, Transport, Logger) ->
 	ConnsSup = ranch_server:get_connections_sup(Ref, AcceptorId),

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -43,7 +43,7 @@ init([Ref, NumAcceptors, Transport]) ->
 	ranch_server:set_addr(Ref, Addr),
 	Procs = [
 		{{acceptor, self(), N}, {ranch_acceptor, start_link, [
-			LSocket, Transport, Logger, ranch_server:get_connections_sup(Ref, N)
+			Ref, N, LSocket, Transport, Logger
 		]}, permanent, brutal_kill, worker, []}
 			|| N <- lists:seq(1, NumAcceptors)],
 	{ok, {{one_for_one, 1, 5}, Procs}}.

--- a/src/ranch_conns_sup_sup.erl
+++ b/src/ranch_conns_sup_sup.erl
@@ -19,16 +19,17 @@
 -export([start_link/4]).
 -export([init/1]).
 
-start_link(Ref, NumAcceptors, Transport, Protocol) ->
+-spec start_link(ranch:ref(), pos_integer(), ranch:opts(), module()) -> {ok, pid()}.
+start_link(Ref, NumConnsSups, Transport, Protocol) ->
 	ok = ranch_server:cleanup_connections_sups(Ref),
 	supervisor:start_link(?MODULE, {
-		Ref, NumAcceptors, Transport, Protocol
+		Ref, NumConnsSups, Transport, Protocol
 	}).
 
-init({Ref, NumAcceptors, Transport, Protocol}) ->
+init({Ref, NumConnsSups, Transport, Protocol}) ->
 	ChildSpecs = [
 		{{ranch_conns_sup, N}, {ranch_conns_sup, start_link,
 				[Ref, N, Transport, Protocol]},
 			permanent, infinity, supervisor, [ranch_conns_sup]}
-		|| N <- lists:seq(1, NumAcceptors)],
+		|| N <- lists:seq(1, NumConnsSups)],
 	{ok, {{one_for_one, 1, 5}, ChildSpecs}}.


### PR DESCRIPTION
Introduction of a new transport option, `num_conns_sups` to configure the number of connection supervisors, as mentioned in https://github.com/ninenines/ranch/issues/110#issuecomment-489544131. Defaults to the value of `num_acceptors`.