### PR TITLE
enable specifying number of listen sockets

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -53,6 +53,7 @@
 	logger => module(),
 	num_acceptors => pos_integer(),
 	num_conns_sups => pos_integer(),
+	num_listen_sockets => pos_integer(),
 	shutdown => timeout() | brutal_kill,
 	socket_opts => any()
 }.

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -26,27 +26,49 @@ start_link(Ref, NumAcceptors, Transport) ->
 init([Ref, NumAcceptors, Transport]) ->
 	TransOpts = ranch_server:get_transport_options(Ref),
 	Logger = maps:get(logger, TransOpts, error_logger),
+	NumListenSockets = maps:get(num_listen_sockets, TransOpts, 1),
 	SocketOpts = maps:get(socket_opts, TransOpts, []),
 	%% We temporarily put the logger in the process dictionary
 	%% so that it can be used from ranch:filter_options. The
 	%% interface as it currently is does not allow passing it
 	%% down otherwise.
 	put(logger, Logger),
-	LSocket = case Transport:listen(SocketOpts) of
+	LSockets = start_listen_sockets(Ref, NumListenSockets, Transport, SocketOpts, Logger),
+	erase(logger),
+	Procs = [begin
+		LSocketId = (AcceptorId rem NumListenSockets) +1,
+		{_, LSocket} = lists:keyfind(LSocketId, 1, LSockets),
+		{
+			{acceptor, self(), AcceptorId},
+			{ranch_acceptor, start_link, [Ref, AcceptorId, LSocket, Transport, Logger]},
+			permanent, brutal_kill, worker, []
+		}
+	end || AcceptorId <- lists:seq(1, NumAcceptors)],
+	{ok, {{one_for_one, 1, 5}, Procs}}.
+
+-spec start_listen_sockets(any(), pos_integer(), module(), list(), module()) ->
+	[{pos_integer(), inet:socket()}].
+start_listen_sockets(Ref, NumListenSockets, Transport, SocketOpts, Logger) when NumListenSockets > 0 ->
+	BaseSocket = start_listen_socket(Ref, Transport, SocketOpts, Logger),
+	{ok, Addr = {_, Port}} = Transport:sockname(BaseSocket),
+	ranch_server:set_addr(Ref, Addr),
+	SocketOpts1 = case lists:keyfind(port, 1, SocketOpts) of
+		{port, Port} ->
+			SocketOpts;
+		_ ->
+			[{port, Port}|lists:keydelete(port, 1, SocketOpts)]
+	end,
+	[{1, BaseSocket}|[{N, start_listen_socket(Ref, Transport, SocketOpts1, Logger)} ||
+		N <- lists:seq(2, NumListenSockets)]].
+
+-spec start_listen_socket(any(), module(), list(), module()) -> inet:socket().
+start_listen_socket(Ref, Transport, SocketOpts, Logger) ->
+	case Transport:listen(SocketOpts) of
 		{ok, Socket} ->
-			erase(logger),
 			Socket;
 		{error, Reason} ->
 			listen_error(Ref, Transport, SocketOpts, Reason, Logger)
-	end,
-	{ok, Addr} = Transport:sockname(LSocket),
-	ranch_server:set_addr(Ref, Addr),
-	Procs = [
-		{{acceptor, self(), N}, {ranch_acceptor, start_link, [
-			Ref, N, LSocket, Transport, Logger
-		]}, permanent, brutal_kill, worker, []}
-			|| N <- lists:seq(1, NumAcceptors)],
-	{ok, {{one_for_one, 1, 5}, Procs}}.
+	end.
 
 -spec listen_error(any(), module(), any(), atom(), module()) -> no_return().
 listen_error(Ref, Transport, SocketOpts0, Reason, Logger) ->

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -41,6 +41,8 @@ groups() ->
 		tcp_getopts_capability,
 		tcp_getstat_capability,
 		tcp_upgrade,
+		tcp_dedicated_sockets,
+		tcp_dedicated_sockets_reuseport_disabled,
 		tcp_error_eaddrinuse,
 		tcp_error_eacces
 	]}, {ssl, [
@@ -53,6 +55,8 @@ groups() ->
 		ssl_upgrade_from_tcp,
 		ssl_getopts_capability,
 		ssl_getstat_capability,
+		ssl_dedicated_sockets,
+		ssl_dedicated_sockets_reuseport_disabled,
 		ssl_error_eaddrinuse,
 		ssl_error_no_cert,
 		ssl_error_eacces
@@ -399,6 +403,48 @@ ssl_accept_error(_) ->
 	true = is_process_alive(AcceptorPid),
 	ok = ranch:stop_listener(Name).
 
+ssl_dedicated_sockets(_) ->
+	case do_os_supports_reuseport() of
+		true ->
+			ok = do_ssl_dedicated_sockets();
+		false ->
+			{skip, "No SO_REUSEPORT support."}
+	end.
+
+do_ssl_dedicated_sockets() ->
+	doc("Ensure that dedicated_acceptor_sockets works with SSL."),
+	Name = name(),
+	Opts = ct_helper:get_certs_from_ets(),
+	{ok, ListenerSupPid} = ranch:start_listener(Name,
+		ranch_ssl, #{num_acceptors => 10,
+			num_listen_sockets => 10,
+			socket_opts => [{raw, 1, 15, <<1:32/native>>}|Opts]},
+		echo_protocol, []),
+	10 = length(do_get_listener_sockets(ListenerSupPid)),
+	ok = ranch:stop_listener(Name),
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
+
+ssl_dedicated_sockets_reuseport_disabled(_) ->
+	case do_os_supports_reuseport() of
+		true ->
+			ok = do_ssl_dedicated_sockets_reuseport_disabled();
+		false ->
+			{skip, "No SO_REUSEPORT support."}
+	end.
+
+do_ssl_dedicated_sockets_reuseport_disabled() ->
+	doc("Ensure that dedicated_acceptor_sockets fails with SSL if SO_REUSEPORT is disabled."),
+	Name = name(),
+	Opts = ct_helper:get_certs_from_ets(),
+	{error, eaddrinuse} = ranch:start_listener(Name,
+		ranch_ssl, #{num_acceptors => 10,
+			num_listen_sockets => 10,
+			socket_opts => [{raw, 1, 15, <<0:32/native>>}|Opts]},
+		echo_protocol, []),
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
+
 ssl_active_echo(_) ->
 	doc("Ensure that active mode works with SSL transport."),
 	Name = name(),
@@ -621,6 +667,46 @@ ssl_error_eacces(_) ->
 	end.
 
 %% tcp.
+
+tcp_dedicated_sockets(_) ->
+	case do_os_supports_reuseport() of
+		true ->
+			ok = do_tcp_dedicated_sockets();
+		false ->
+			{skip, "No SO_REUSEPORT support."}
+	end.
+
+do_tcp_dedicated_sockets() ->
+	doc("Ensure that dedicated_acceptor_sockets works with TCP."),
+	Name = name(),
+	{ok, ListenerSupPid} = ranch:start_listener(Name,
+		ranch_tcp, #{num_acceptors => 10,
+			num_listen_sockets => 10,
+			socket_opts => [{raw, 1, 15, <<1:32/native>>}]},
+		echo_protocol, []),
+	10 = length(do_get_listener_sockets(ListenerSupPid)),
+	ok = ranch:stop_listener(Name),
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
+
+tcp_dedicated_sockets_reuseport_disabled(_) ->
+	case do_os_supports_reuseport() of
+		true ->
+			ok = do_tcp_dedicated_sockets_reuseport_disabled();
+		false ->
+			{skip, "No SO_REUSEPORT support."}
+	end.
+
+do_tcp_dedicated_sockets_reuseport_disabled() ->
+	doc("Ensure that dedicated_acceptor_sockets fails with TCP if SO_REUSEPORT is disabled."),
+	Name = name(),
+	{error, eaddrinuse} = ranch:start_listener(Name,
+		ranch_tcp, #{num_acceptors => 10,
+			num_listen_sockets => 10,
+			socket_opts => [{raw, 1, 15, <<0:32/native>>}]},
+		echo_protocol, []),
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
 
 tcp_active_echo(_) ->
 	doc("Ensure that active mode works with TCP transport."),
@@ -998,15 +1084,17 @@ supervisor_changed_options_restart(_) ->
 		ranch_tcp, [{send_timeout, 300000}],
 		echo_protocol, []),
 	%% Ensure send_timeout is really set to initial value.
+	[ListenerSocket1] = do_get_listener_sockets(ListenerSupPid1),
 	{ok, [{send_timeout, 300000}]}
-		= inet:getopts(do_get_listener_socket(ListenerSupPid1), [send_timeout]),
+		= inet:getopts(ListenerSocket1, [send_timeout]),
 	%% Change send_timeout option.
 	ok = ranch:suspend_listener(Name),
 	ok = ranch:set_transport_options(Name, [{send_timeout, 300001}]),
 	ok = ranch:resume_listener(Name),
 	%% Ensure send_timeout is really set to the changed value.
+	[ListenerSocket2] = do_get_listener_sockets(ListenerSupPid1),
 	{ok, [{send_timeout, 300001}]}
-		= inet:getopts(do_get_listener_socket(ListenerSupPid1), [send_timeout]),
+		= inet:getopts(ListenerSocket2, [send_timeout]),
 	%% Crash the listener_sup process, allow a short time for restart to succeed.
 	exit(ListenerSupPid1, kill),
 	timer:sleep(1000),
@@ -1014,8 +1102,9 @@ supervisor_changed_options_restart(_) ->
 	[ListenerSupPid2] = [Pid || {{ranch_listener_sup, Ref}, Pid, supervisor, _}
 		<- supervisor:which_children(ranch_sup), Ref =:= Name],
 	%% Ensure send_timeout is still set to the changed value.
+	[ListenerSocket3] = do_get_listener_sockets(ListenerSupPid2),
 	{ok, [{send_timeout, 300001}]}
-		= inet:getopts(do_get_listener_socket(ListenerSupPid2), [send_timeout]),
+		= inet:getopts(ListenerSocket3, [send_timeout]),
 	ok = ranch:stop_listener(Name),
 	{'EXIT', _} = begin catch ranch:get_port(Name) end,
 	ok.
@@ -1245,12 +1334,11 @@ clean_traces() ->
 		ok
 	end.
 
-do_get_listener_socket(ListenerSupPid) ->
+do_get_listener_sockets(ListenerSupPid) ->
 	[AcceptorsSupPid] = [Pid || {ranch_acceptors_sup, Pid, supervisor, _}
 		<- supervisor:which_children(ListenerSupPid)],
 	{links, Links} = erlang:process_info(AcceptorsSupPid, links),
-	[LSocket] = [P || P <- Links, is_port(P)],
-	LSocket.
+	[P || P <- Links, is_port(P)].
 
 do_conns_which_children(Name) ->
 	Conns = [supervisor:which_children(ConnsSup) ||
@@ -1273,3 +1361,10 @@ do_conns_count_children(Name) ->
 		[supervisor:count_children(ConnsSup) ||
 			{_, ConnsSup} <- ranch_server:get_connections_sups(Name)]
 	).
+
+do_os_supports_reuseport() ->
+	case {os:type(), os:version()} of
+		{{unix, linux}, {Major, _, _}} when Major>3 -> true;
+		{{unix, linux}, {3, Minor, _}} when Minor>=9 -> true;
+		_ -> false
+	end.


### PR DESCRIPTION
(In response to #215)

Introduces a new transport option `num_listen_sockets => pos_integer()` to enable `ranch` to start more than just one individual listen socket. The socket options must be such that this is actually possible, ie by setting `SO_REUSEPORT` via raw options. Whether this socket option is available and how to enable it is OS-dependent.