### PR TITLE
fix premature ranch_server:set_addr

### DIFF
--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -51,7 +51,6 @@ init([Ref, NumAcceptors, Transport]) ->
 start_listen_sockets(Ref, NumListenSockets, Transport, SocketOpts0, Logger) when NumListenSockets > 0 ->
 	BaseSocket = start_listen_socket(Ref, Transport, SocketOpts0, Logger),
 	{ok, Addr={_, Port}} = Transport:sockname(BaseSocket),
-	ranch_server:set_addr(Ref, Addr),
 	SocketOpts = case lists:keyfind(port, 1, SocketOpts0) of
 		{port, Port} ->
 			SocketOpts0;
@@ -61,6 +60,7 @@ start_listen_sockets(Ref, NumListenSockets, Transport, SocketOpts0, Logger) when
 	ExtraSockets = [
 		{N, start_listen_socket(Ref, Transport, SocketOpts, Logger)}
 	|| N <- lists:seq(2, NumListenSockets)],
+	ranch_server:set_addr(Ref, Addr),
 	[{1, BaseSocket}|ExtraSockets].
 
 -spec start_listen_socket(any(), module(), list(), module()) -> inet:socket().


### PR DESCRIPTION
With `num_listen_sockets`>1 and SO_REUSEPORT disabled/not available, the startup of `ranch_acceptors_sup` fails because extra sockets cannot be created. But because `ranch_server:set_addr` is called right after the creation of the first socket succeeded, `ranch:get_port` etc may still return an ok tuple until it notices that the listener is in fact down. This PR moves the registration of the address after the creation of the extra sockets.