### PR TITLE
Add tests for active N mode

### DIFF
--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -29,6 +29,7 @@ all() ->
 groups() ->
 	[{tcp, [
 		tcp_active_echo,
+		tcp_active_n_echo,
 		tcp_echo,
 		tcp_graceful,
 		tcp_inherit_options,
@@ -48,6 +49,7 @@ groups() ->
 	]}, {ssl, [
 		ssl_accept_error,
 		ssl_active_echo,
+		ssl_active_n_echo,
 		ssl_echo,
 		ssl_graceful,
 		ssl_sni_echo,
@@ -464,6 +466,36 @@ ssl_active_echo(_) ->
 	{'EXIT', _} = begin catch ranch:get_port(Name) end,
 	ok.
 
+ssl_active_n_echo(_) ->
+	case application:get_key(ssl, vsn) of
+		{ok, Vsn} when Vsn >= "9.2" ->
+			do_ssl_active_n_echo();
+		_ ->
+			{skip, "No Active N support."}
+	end.
+
+do_ssl_active_n_echo() ->
+	doc("Ensure that active N mode works with SSL transport."),
+	Name = name(),
+	Opts = ct_helper:get_certs_from_ets(),
+	{ok, _} = ranch:start_listener(Name,
+		ranch_ssl, Opts,
+		batch_echo_protocol, [{batch_size, 3}]),
+	Port = ranch:get_port(Name),
+	{ok, Socket} = ssl:connect("localhost", Port, [binary, {active, false}, {packet, raw}]),
+	ok = ssl:send(Socket, <<"One">>),
+	{ok, <<"OK">>} = ssl:recv(Socket, 2, 1000),
+	ok = ssl:send(Socket, <<"Two">>),
+	{ok, <<"OK">>} = ssl:recv(Socket, 2, 1000),
+	ok = ssl:send(Socket, <<"Three">>),
+	{ok, <<"OK">>} = ssl:recv(Socket, 2, 1000),
+	{ok, <<"OneTwoThree">>} = ssl:recv(Socket, 11, 1000),
+	ok = ranch:stop_listener(Name),
+	{error, closed} = ssl:recv(Socket, 0, 1000),
+	%% Make sure the listener stopped.
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
+
 ssl_echo(_) ->
 	doc("Ensure that passive mode works with SSL transport."),
 	Name = name(),
@@ -722,6 +754,27 @@ tcp_active_echo(_) ->
 	{ok, Socket} = gen_tcp:connect("localhost", Port, [binary, {active, false}, {packet, raw}]),
 	ok = gen_tcp:send(Socket, <<"TCP Ranch is working!">>),
 	{ok, <<"TCP Ranch is working!">>} = gen_tcp:recv(Socket, 21, 1000),
+	ok = ranch:stop_listener(Name),
+	{error, closed} = gen_tcp:recv(Socket, 0, 1000),
+	%% Make sure the listener stopped.
+	{'EXIT', _} = begin catch ranch:get_port(Name) end,
+	ok.
+
+tcp_active_n_echo(_) ->
+	doc("Ensure that active N mode works with TCP transport."),
+	Name = name(),
+	{ok, _} = ranch:start_listener(Name,
+		ranch_tcp, #{},
+		batch_echo_protocol, [{batch_size, 3}]),
+	Port = ranch:get_port(Name),
+	{ok, Socket} = gen_tcp:connect("localhost", Port, [binary, {active, false}, {packet, raw}]),
+	ok = gen_tcp:send(Socket, <<"One">>),
+	{ok, <<"OK">>} = gen_tcp:recv(Socket, 2, 1000),
+	ok = gen_tcp:send(Socket, <<"Two">>),
+	{ok, <<"OK">>} = gen_tcp:recv(Socket, 2, 1000),
+	ok = gen_tcp:send(Socket, <<"Three">>),
+	{ok, <<"OK">>} = gen_tcp:recv(Socket, 2, 1000),
+	{ok, <<"OneTwoThree">>} = gen_tcp:recv(Socket, 11, 1000),
 	ok = ranch:stop_listener(Name),
 	{error, closed} = gen_tcp:recv(Socket, 0, 1000),
 	%% Make sure the listener stopped.

--- a/test/batch_echo_protocol.erl
+++ b/test/batch_echo_protocol.erl
@@ -1,0 +1,30 @@
+-module(batch_echo_protocol).
+-behaviour(ranch_protocol).
+
+-export([start_link/3]).
+-export([init/3]).
+
+start_link(Ref, Transport, [{batch_size, N}]) ->
+	Pid = spawn_link(?MODULE, init, [Ref, Transport, N]),
+	{ok, Pid}.
+
+init(Ref, Transport, N) ->
+	{ok, Socket} = ranch:handshake(Ref),
+	Transport:setopts(Socket, [{active, N}]),
+	loop(Socket, Transport, N, <<>>).
+
+loop(Socket, Transport, N, Acc) ->
+	{OK, Closed, Error, Passive} = Transport:messages(),
+	receive
+		{OK, Socket, Data} ->
+			Transport:send(Socket, <<"OK">>),
+			loop(Socket, Transport, N, <<Acc/binary, Data/binary>>);
+		{Passive, Socket} ->
+			Transport:send(Socket, Acc),
+			Transport:setopts(Socket, [{active, N}]),
+			loop(Socket, Transport, N, <<>>);
+		{Closed, Socket} ->
+			ok;
+		{Error, Socket, _} ->
+			ok = Transport:close(Socket)
+	end.


### PR DESCRIPTION
This PR adds two tests to ensure that `{active, N}` mode works and the `tcp_passive`/`ssl_passive` messages are delivered.