### PR TITLE
Adaptive restart intensity for acceptor and connection supervisors

### DIFF
--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -41,7 +41,7 @@ init([Ref, NumAcceptors, Transport]) ->
 			shutdown => brutal_kill
 		}
 	end || AcceptorId <- lists:seq(1, NumAcceptors)],
-	{ok, {#{}, Procs}}.
+	{ok, {#{intensity => 1 + ceil(math:log2(NumAcceptors))}, Procs}}.
 
 -spec start_listen_sockets(any(), pos_integer(), module(), map(), module())
 	-> [{pos_integer(), inet:socket()}].

--- a/src/ranch_conns_sup_sup.erl
+++ b/src/ranch_conns_sup_sup.erl
@@ -32,4 +32,4 @@ init({Ref, NumConnsSups, Transport, Protocol}) ->
 		start => {ranch_conns_sup, start_link, [Ref, N, Transport, Protocol]},
 		type => supervisor
 	} || N <- lists:seq(1, NumConnsSups)],
-	{ok, {#{}, ChildSpecs}}.
+	{ok, {#{intensity => 1 + ceil(math:log2(NumConnsSups))}, ChildSpecs}}.


### PR DESCRIPTION
The changes in this PR set the restart intensities of acceptor_sup and conns_sup_sup to the number of acceptors and conns_sups, respectively.