### PR TITLE
Supervised embedded mode

### DIFF
--- a/doc/src/manual/ranch.child_spec.asciidoc
+++ b/doc/src/manual/ranch.child_spec.asciidoc
@@ -16,18 +16,20 @@ child_spec(Ref       :: ranch_ref(),
     -> supervisor:child_spec()
 ----
 
-Build child specifications for a new listener.
+Build child specifications for a new listener which can
+be embedded directly in an application's supervision
+tree.
 
-This function can be used to embed a listener directly
-in an application's supervision tree.
+The actual listener is placed under a supervisor which
+monitors `ranch_server` via a proxy process and will
+restart the listener if `ranch_server` crashes.
 
 == Arguments
 
 Ref::
 
 The listener name is used to refer to this listener in
-future calls, for example when stopping it or when
-updating the configuration.
+future calls, for example when updating the configuration.
 +
 It can be any Erlang term. An atom is generally good enough,
 for example `api`, `my_app_clear` or `my_app_tls`.
@@ -74,6 +76,8 @@ Child specifications are returned.
 
 == Changelog
 
+* *2.0*: The actual listener is placed under a supervisor in order to
+         restart the listener if `ranch_server` crashes.
 * *2.0*: The `TransOpts` argument must no longer contain
          Ranch-specific options if given as a list. Use a map.
 * *1.4*: The `NumAcceptors` argument was moved to the transport options.

--- a/ebin/ranch.app
+++ b/ebin/ranch.app
@@ -1,7 +1,7 @@
 {application, 'ranch', [
 	{description, "Socket acceptor pool for TCP protocols."},
 	{vsn, "1.7.1"},
-	{modules, ['ranch','ranch_acceptor','ranch_acceptors_sup','ranch_app','ranch_conns_sup','ranch_conns_sup_sup','ranch_crc32c','ranch_listener_sup','ranch_protocol','ranch_proxy_header','ranch_server','ranch_ssl','ranch_sup','ranch_tcp','ranch_transport']},
+	{modules, ['ranch','ranch_acceptor','ranch_acceptors_sup','ranch_app','ranch_conns_sup','ranch_conns_sup_sup','ranch_crc32c','ranch_embedded_sup','ranch_listener_sup','ranch_protocol','ranch_proxy_header','ranch_server','ranch_server_proxy','ranch_ssl','ranch_sup','ranch_tcp','ranch_transport']},
 	{registered, [ranch_sup,ranch_server]},
 	{applications, [kernel,stdlib,ssl]},
 	{mod, {ranch_app, []}},

--- a/src/ranch_embedded_sup.erl
+++ b/src/ranch_embedded_sup.erl
@@ -1,0 +1,34 @@
+%% Copyright (c) 2019, Jan Uhlig <ju@mailingwork.de>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-module(ranch_embedded_sup).
+
+-behavior(supervisor).
+
+-export([start_link/5]).
+-export([init/1]).
+
+-spec start_link(ranch:ref(), module(), any(), module(), any())
+        -> {ok, pid()}.
+start_link(Ref, Transport, TransOpts, Protocol, ProtoOpts) ->
+	supervisor:start_link(?MODULE, {Ref, Transport, TransOpts, Protocol, ProtoOpts}).
+
+init({Ref, Transport, TransOpts, Protocol, ProtoOpts}) ->
+	Proxy = #{id => ranch_server_proxy,
+		start => {ranch_server_proxy, start_link, []},
+		shutdown => brutal_kill},
+	Listener = #{id => {ranch_listener_sup, Ref},
+		start => {ranch_listener_sup, start_link, [Ref, Transport, TransOpts, Protocol, ProtoOpts]},
+		type => supervisor},
+	{ok, {#{strategy => rest_for_one}, [Proxy, Listener]}}.

--- a/src/ranch_server_proxy.erl
+++ b/src/ranch_server_proxy.erl
@@ -1,0 +1,61 @@
+%% Copyright (c) 2019, Jan Uhlig <ju@mailingwork.de>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-module(ranch_server_proxy).
+
+-behavior(gen_server).
+
+-export([start_link/0]).
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+-export([code_change/3]).
+
+start_link() ->
+	gen_server:start_link(?MODULE, [], []).
+
+init([]) ->
+	case wait_ranch_server(50) of
+		{ok, Monitor} ->
+			{ok, Monitor, hibernate};
+		{error, Reason} ->
+			{stop, Reason}
+	end.
+
+handle_call(_, _, Monitor) ->
+	{noreply, Monitor, hibernate}.
+
+handle_cast(_, Monitor) ->
+	{noreply, Monitor, hibernate}.
+
+handle_info({'DOWN', Monitor, process, _, Reason}, Monitor) ->
+	{stop, Reason, Monitor};
+handle_info(_, Monitor) ->
+	{noreply, Monitor, hibernate}.
+
+code_change(_, Monitor, _) ->
+	{ok, Monitor}.
+
+wait_ranch_server(N) ->
+	case whereis(ranch_server) of
+		undefined when N > 0 ->
+			receive after 100 -> ok end,
+			wait_ranch_server(N - 1);
+		undefined ->
+			{error, noproc};
+		Pid ->
+			Monitor = monitor(process, Pid),
+			{ok, Monitor}
+	end.

--- a/test/embedded_sup.erl
+++ b/test/embedded_sup.erl
@@ -23,6 +23,6 @@ start_listener(SupPid, Ref, Transport, TransOpts, Protocol, ProtoOpts) ->
 	).
 
 stop_listener(SupPid, Ref) ->
-	ok = supervisor:terminate_child(SupPid, {ranch_listener_sup, Ref}),
-	ok = supervisor:delete_child(SupPid, {ranch_listener_sup, Ref}),
+	ok = supervisor:terminate_child(SupPid, {ranch_embedded_sup, Ref}),
+	ok = supervisor:delete_child(SupPid, {ranch_embedded_sup, Ref}),
 	ranch_server:cleanup_listener_opts(Ref).


### PR DESCRIPTION
#211, and as discussed on IRC.

The embedded_sup starts the ranch_server_proxy first, which acts as a guard to ensure the presence of ranch_server. To acommodate for the possibility of ranch_server being (re-)started after the proxy, it retries to establish a monitor a few times before giving up and refusing to start. If it can successfully establish the monitor, the listener can then start, and the proxy will.

If ranch_server goes away (crashes, is turned off, ...), the proxy will notice via the monitor and exit, which the embedded sup will in turn notice, shut down the listener, and try to restart in the manner outlined above.