### PR TITLE
WIP: Apply ranch transport options in set_transport_options

### DIFF
--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -107,7 +107,7 @@ init(Parent, Ref, Id, Transport, Protocol) ->
 	TransOpts = ranch_server:get_transport_options(Ref),
 	ConnType = maps:get(connection_type, TransOpts, worker),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
-	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
+	HandshakeTimeout = ranch_server:get_handshake_timeout(Ref),
 	Logger = maps:get(logger, TransOpts, logger),
 	ProtoOpts = ranch_server:get_protocol_options(Ref),
 	ok = proc_lib:init_ack(Parent, {ok, self()}),
@@ -165,6 +165,10 @@ loop(State=#state{parent=Parent, ref=Ref, conn_type=ConnType,
 				CurConns, NbChildren, []);
 		{set_max_conns, MaxConns2} ->
 			loop(State#state{max_conns=MaxConns2},
+				CurConns, NbChildren, Sleepers);
+		%% Upgrade the handshake timeout.
+		{set_handshake_timeout, HandshakeTimeout2} ->
+			loop(State#state{handshake_timeout=HandshakeTimeout2},
 				CurConns, NbChildren, Sleepers);
 		%% Upgrade the protocol options.
 		{set_opts, Opts2} ->

--- a/src/ranch_listener_sup.erl
+++ b/src/ranch_listener_sup.erl
@@ -24,7 +24,8 @@ start_link(Ref, Transport, TransOpts, Protocol, ProtoOpts) ->
 	NumAcceptors = maps:get(num_acceptors, TransOpts, 10),
 	NumConnsSups = maps:get(num_conns_sups, TransOpts, NumAcceptors),
 	MaxConns = maps:get(max_connections, TransOpts, 1024),
-	ranch_server:set_new_listener_opts(Ref, MaxConns, TransOpts, ProtoOpts,
+	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
+	ranch_server:set_new_listener_opts(Ref, MaxConns, HandshakeTimeout, TransOpts, ProtoOpts,
 		[Ref, Transport, TransOpts, Protocol, ProtoOpts]),
 	supervisor:start_link(?MODULE, {
 		Ref, NumAcceptors, NumConnsSups, Transport, Protocol


### PR DESCRIPTION
#254

Changes via `set_transport_options/2` to the `max_connections` and `handshake_timeout` options will now be applied to a listener. Changes to the `socket_opts`, `num_acceptors` and `num_listen_sockets` options will implicitly take effect when the listener is resumed, as those are read from the transport options on start of the acceptors_sup. Changes to the other options have no effect (until the listener is restarted).

The test is a little clumsy. Since the effect of a change in the `handshake_timeout` is difficult to observe directly, it obtains the state of the conns_sups and checks the respective values to see if they have changed accordingly. If you have any better idea, tell me.

The new `set_handshake_timeout/2` function can be used on a running listener to change the `handshake_timeout`, like `set_max_connections` does.

Docs are still missing, will write them later when this is found to be good so far.