### PR TITLE
Set transport options without suspend

### DIFF
--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -358,14 +358,23 @@ Opts = ranch:get_protocol_options(tcp_echo).
 
 === Changing transport options
 
-Ranch allows you to change the transport options of a listener, for
-example to make it listen on a different port.
+Ranch allows you to change the transport options of a listener with
+the `ranch:set_transport_options/2` function, for example to change the
+number of acceptors or to make it listen on a different port.
 
-To change transport options, the listener has to be suspended first.
-Then you are allowed to change the transport options by calling
-`ranch:set_transport_options/2` with the listener name and the new
-transport options as arguments.
-After that, you can resume the listener.
+Changes to the following options will take effect...
+
+* immediately:
+** `max_connections`
+** `handshake_timeout`
+** `shutdown`
+* only after the listener has been suspended and resumed:
+** `num_acceptors`
+** `num_listen_sockets`
+** `socket_opts`
+* only when the entire listener is restarted:
+** `num_conns_sups`
+** `logger`
 
 .Changing the transport options
 

--- a/doc/src/manual/ranch.set_transport_options.asciidoc
+++ b/doc/src/manual/ranch.set_transport_options.asciidoc
@@ -9,16 +9,25 @@ ranch:set_transport_options - Set the transport options
 [source,erlang]
 ----
 set_transport_options(Ref       :: ranch:ref(),
-                      TransOpts :: any())
-    -> ok | {error, running}
+                      TransOpts :: ranch:opts())
+    -> ok | {error, Reason :: term()}
 ----
 
 Set the transport options.
 
-The listener must be suspended for this call to succeed.
-If the listener is running, `{error, running}` will be returned.
+Changes to the following options will take effect...
 
-The change will take effect when the listener resumes.
+* immediately:
+** `max_connections`
+** `handshake_timeout`
+** `shutdown`
+* only after the listener has been suspended and resumed:
+** `num_acceptors`
+** `num_listen_sockets`
+** `socket_opts`
+* only when the entire listener is restarted:
+** `num_conns_sups`
+** `logger`
 
 == Arguments
 
@@ -32,10 +41,15 @@ The new transport options.
 
 == Return value
 
-The atom `ok` is always returned. It can be safely ignored.
+The atom `ok` is returned on success.
+
+An error tuple is returned on failure, for example if the given
+transport options contain invalid values.
 
 == Changelog
 
+* *2.0*: The restriction that the listener must be suspended
+         has been removed.
 * *2.0*: The `TransOpts` argument must no longer contain
          Ranch-specific options if given as a list. Use a map.
 

--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -18,15 +18,15 @@
 -export([start_link/3]).
 -export([init/1]).
 
--spec start_link(ranch:ref(), pos_integer(), module())
+-spec start_link(ranch:ref(), module(), module())
 	-> {ok, pid()}.
-start_link(Ref, NumAcceptors, Transport) ->
-	supervisor:start_link(?MODULE, [Ref, NumAcceptors, Transport]).
+start_link(Ref, Transport, Logger) ->
+	supervisor:start_link(?MODULE, [Ref, Transport, Logger]).
 
 -spec init([term()]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
-init([Ref, NumAcceptors, Transport]) ->
+init([Ref, Transport, Logger]) ->
 	TransOpts = ranch_server:get_transport_options(Ref),
-	Logger = maps:get(logger, TransOpts, logger),
+	NumAcceptors = maps:get(num_acceptors, TransOpts, 10),
 	NumListenSockets = maps:get(num_listen_sockets, TransOpts, 1),
 	%% We temporarily put the logger in the process dictionary
 	%% so that it can be used from ranch:filter_options. The

--- a/src/ranch_conns_sup_sup.erl
+++ b/src/ranch_conns_sup_sup.erl
@@ -19,19 +19,22 @@
 -export([start_link/4]).
 -export([init/1]).
 
--spec start_link(ranch:ref(), pos_integer(), ranch:opts(), module()) -> {ok, pid()}.
-start_link(Ref, NumConnsSups, Transport, Protocol) ->
+-spec start_link(ranch:ref(), module(), module(), module()) -> {ok, pid()}.
+start_link(Ref, Transport, Protocol, Logger) ->
 	ok = ranch_server:cleanup_connections_sups(Ref),
 	supervisor:start_link(?MODULE, {
-		Ref, NumConnsSups, Transport, Protocol
+		Ref, Transport, Protocol, Logger
 	}).
 
--spec init({ranch:ref(), pos_integer(), module(), module()})
+-spec init({ranch:ref(), module(), module(), module()})
 	-> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
-init({Ref, NumConnsSups, Transport, Protocol}) ->
+init({Ref, Transport, Protocol, Logger}) ->
+	TransOpts = ranch_server:get_transport_options(Ref),
+	NumAcceptors = maps:get(num_acceptors, TransOpts, 10),
+	NumConnsSups = maps:get(num_conns_sups, TransOpts, NumAcceptors),
 	ChildSpecs = [#{
 		id => {ranch_conns_sup, N},
-		start => {ranch_conns_sup, start_link, [Ref, N, Transport, Protocol]},
+		start => {ranch_conns_sup, start_link, [Ref, N, Transport, TransOpts, Protocol, Logger]},
 		type => supervisor
 	} || N <- lists:seq(1, NumConnsSups)],
 	{ok, {#{intensity => 1 + ceil(math:log2(NumConnsSups))}, ChildSpecs}}.

--- a/src/ranch_server.erl
+++ b/src/ranch_server.erl
@@ -202,7 +202,7 @@ handle_call({set_trans_opts, Ref, Opts}, _, State) ->
 	{reply, ok, State};
 handle_call({set_proto_opts, Ref, Opts}, _, State) ->
 	ets:insert(?TAB, {{proto_opts, Ref}, Opts}),
-	_ = [ConnsSup ! {set_opts, Opts} || {_, ConnsSup} <- get_connections_sups(Ref)],
+	_ = [ConnsSup ! {set_protocol_options, Opts} || {_, ConnsSup} <- get_connections_sups(Ref)],
 	{reply, ok, State};
 handle_call(_Request, _From, State) ->
 	{reply, ignore, State}.


### PR DESCRIPTION
#254 again, second try.

This PR lifts the restriction that the listener must be suspended in order to change the transport options.

* Changes to the `max_connections`, `handshake_timeout`, and `shutdown` options take effect immediately.
* Changes to the `num_acceptors`, `num_listen_sockets`, and `socket_opts` take effect when a listener is (suspended and) resumed.
* Changes to other options except `logger` will not take effect until the conns_sup_sup is restarted.
* Changes to the `logger` option will not take effect until the listener_sup is restarted.

Some restructuring was needed to achieve consistency.

* `num_acceptors` is now fetched from the transport options in the acceptors_sup itself, instead of being given to it. Otherwise, it wouldn't take effect on resume; `num_listen_sockets`, however, _would_ take effect, which is both unexpected and dangerous (there must not be more listen sockets than acceptors).
* The transport options are now fetched in the conns_sup_sup and handed down to the individual conns_sups in their child specs, instead of fetching them themselves individually. Otherwise, restarts of individual conns_sups will lead to some running with the old and some with the changed transport options.
* `logger` is now fetched from the transport options in the listener_sup and handed down to the conns_sups and acceptors_sup, instead of being fetched in those places individually. Otherwise, changes to it will take effect in the acceptors on resume, but not in the conns_sups.