### PR TITLE
Fix documentation for set_transport_options

### DIFF
--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -362,20 +362,6 @@ Ranch allows you to change the transport options of a listener with
 the `ranch:set_transport_options/2` function, for example to change the
 number of acceptors or to make it listen on a different port.
 
-Changes to the following options will take effect...
-
-* immediately:
-** `max_connections`
-** `handshake_timeout`
-** `shutdown`
-* only after the listener has been suspended and resumed:
-** `num_acceptors`
-** `num_listen_sockets`
-** `socket_opts`
-* only when the entire listener is restarted:
-** `num_conns_sups`
-** `logger`
-
 .Changing the transport options
 
 [source,erlang]

--- a/doc/src/manual/ranch.set_transport_options.asciidoc
+++ b/doc/src/manual/ranch.set_transport_options.asciidoc
@@ -26,6 +26,7 @@ Changes to the following options will take effect...
 ** `num_listen_sockets`
 ** `socket_opts`
 * only when the entire listener is restarted:
+** `connection_type`
 ** `num_conns_sups`
 ** `logger`
 


### PR DESCRIPTION
Adds the missing `connection_type` to the manual, and removes the option list from the guide.