### PR TITLE
Prevent side effects in supervisors during hot upgrade

### DIFF
--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -28,7 +28,14 @@ init([Ref, Transport, Logger]) ->
 	TransOpts = ranch_server:get_transport_options(Ref),
 	NumAcceptors = maps:get(num_acceptors, TransOpts, 10),
 	NumListenSockets = maps:get(num_listen_sockets, TransOpts, 1),
-	LSockets = start_listen_sockets(Ref, NumListenSockets, Transport, TransOpts, Logger),
+	LSockets = case get(lsockets) of
+		undefined ->
+			LSockets1 = start_listen_sockets(Ref, NumListenSockets, Transport, TransOpts, Logger),
+			put(lsockets, LSockets1),
+			LSockets1;
+		LSockets1 ->
+			LSockets1
+	end,
 	Procs = [begin
 		LSocketId = (AcceptorId rem NumListenSockets) + 1,
 		{_, LSocket} = lists:keyfind(LSocketId, 1, LSockets),

--- a/src/ranch_app.erl
+++ b/src/ranch_app.erl
@@ -22,6 +22,8 @@
 -spec start(application:start_type(), term()) -> {ok, pid()} | {error, term()}.
 start(_, _) ->
 	_ = consider_profiling(),
+	ranch_server = ets:new(ranch_server, [
+		ordered_set, public, named_table]),
 	ranch_sup:start_link().
 
 -spec stop(term()) -> ok.

--- a/src/ranch_sup.erl
+++ b/src/ranch_sup.erl
@@ -32,8 +32,6 @@ init([]) ->
 		{ok, Value2} -> Value2;
 		undefined -> 5
 	end,
-	ranch_server = ets:new(ranch_server, [
-		ordered_set, public, named_table]),
 	Procs = [
 		#{id => ranch_server, start => {ranch_server, start_link, []}}
 	],


### PR DESCRIPTION
Proof of concept, for review and comments.

Moves the craetion of the ranch_server table into ranch_app:start, and works around side effects in the supervisors init functions to make them hot-code upgradable.