### PR TITLE
Enable connection count alarms

### DIFF
--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -339,26 +339,9 @@ options as values.
 
 Any term is allowed as an alarm name.
 
-Alarm options, defining the alarm behavior, are again a map with the following
-keys:
-
-`type`::
-The alarm type. Currently, `num_connections` is the only allowed type.
-
-`treshold`::
-The alarm treshold. When the number of connections under a connection
-supervisor reaches or exceeds this value, the alarm will trigger and
-call the function given in the `callback` key.
-
-`callback`::
-The alarm function, that is, the function which will be called when the
-alarm is triggered. Its arguments are the listener name, the alarm
-name, the Pid of the triggering connection supervisor, and the Pids of
-all the connection processes under that supervisor.
-
-`cooldown` (5000)::
-The minimum time to elapse before the alarm can trigger again, in
-milliseconds.
+Alarm options include the alarm type and a treshold that, when reached,
+triggers the given callback. A cooldown prevents the alarm from being
+triggered too often.
 
 .Setting an alarm to log warnings when the number of connections exceed 100
 

--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -330,7 +330,7 @@ processes.
 
 === Setting connection count alarms
 
-The `alarms` transport options allows you to configure alarms
+The `alarms` transport option allows you to configure alarms
 which will be triggered when the number of connections under a connection
 supervisor reaches or exceeds the defined treshold.
 
@@ -340,7 +340,7 @@ options as values.
 Any term is allowed as an alarm name.
 
 Alarm options, defining the alarm behavior, are again a map with the following
-keys, all of which are mandatory:
+keys:
 
 `type`::
 The alarm type. Currently, `num_connections` is the only allowed type.
@@ -356,7 +356,7 @@ alarm is triggered. Its arguments are the listener name, the alarm
 name, the Pid of the triggering connection supervisor, and the Pids of
 all the connection processes under that supervisor.
 
-`cooldown`::
+`cooldown` (5000)::
 The minimum time to elapse before the alarm can trigger again, in
 milliseconds.
 
@@ -373,8 +373,7 @@ Alarms = #{
                     "Supervisor ~s of listener ~s "
                     "has ~b connections",
                 [Name, Ref, ConnSup, length(ConnPids)])
-        end,
-        cooldown => 5000
+        end
     }
 },
 {ok, _} = ranch:start_listener(tcp_echo,
@@ -386,8 +385,8 @@ Alarms = #{
 In the example code, an alarm named `my_alarm` is defined, which will
 call the given function when the number of connections under a
 connection supervisor reaches or exceeds 100. When the number of
-connections is still (or again) above 100 after 5 seconds, the
-alarm will trigger again.
+connections is still (or again) above 100 after the default cooldown
+period of 5 seconds, the alarm will trigger again.
 
 === When running out of file descriptors
 

--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -328,6 +328,67 @@ processes.
     echo_protocol, []
 ).
 
+=== Setting connection count alarms
+
+The `alarms` transport options allows you to configure alarms
+which will be triggered when the number of connections under a connection
+supervisor reaches or exceeds the defined treshold.
+
+The `alarms` transport option takes a map with alarm names as keys and alarm
+options as values.
+
+Any term is allowed as an alarm name.
+
+Alarm options, defining the alarm behavior, are again a map with the following
+keys, all of which are mandatory:
+
+`type`::
+The alarm type. Currently, `num_connections` is the only allowed type.
+
+`treshold`::
+The alarm treshold. When the number of connections under a connection
+supervisor reaches or exceeds this value, the alarm will trigger and
+call the function given in the `callback` key.
+
+`callback`::
+The alarm function, that is, the function which will be called when the
+alarm is triggered. Its arguments are the listener name, the alarm
+name, the Pid of the triggering connection supervisor, and the Pids of
+all the connection processes under that supervisor.
+
+`cooldown`::
+The minimum time to elapse before the alarm can trigger again, in
+milliseconds.
+
+.Setting an alarm to log warnings when the number of connections exceed 100
+
+[source,erlang]
+----
+Alarms = #{
+    my_alarm => #{
+        type => num_connections,
+        treshold => 100,
+        callback => fun(Ref, Name, ConnSup, ConnPids]) ->
+            logger:warning("Warning (~s): "
+                    "Supervisor ~s of listener ~s "
+                    "has ~b connections",
+                [Name, Ref, ConnSup, length(ConnPids)])
+        end,
+        cooldown => 5000
+    }
+},
+{ok, _} = ranch:start_listener(tcp_echo,
+    ranch_tcp, #{alarms => Alarms, socket_opts => [{port, 5555}]},
+    echo_protocol, []
+).
+----
+
+In the example code, an alarm named `my_alarm` is defined, which will
+call the given function when the number of connections under a
+connection supervisor reaches or exceeds 100. When the number of
+connections is still (or again) above 100 after 5 seconds, the
+alarm will trigger again.
+
 === When running out of file descriptors
 
 Operating systems have limits on the number of sockets

--- a/doc/src/manual/ranch.asciidoc
+++ b/doc/src/manual/ranch.asciidoc
@@ -88,6 +88,14 @@ Unique name used to refer to a listener.
 [source,erlang]
 ----
 transport_opts(SocketOpts) = #{
+    alarms               => #{
+                                term() => #{
+                                    type := num_connections,
+                                    treshold := non_neg_integer(),
+                                    callback := fun((ref(), term(), pid(), [pid()]) -> any()),
+                                    cooldown => non_neg_integer()
+                                }
+                            },
     connection_type      => worker | supervisor,
     handshake_timeout    => timeout(),
     max_connections      => max_conns(),
@@ -106,6 +114,38 @@ The transport options are a combination of Ranch-specific
 options and transport-specific socket options.
 
 None of the options are required.
+
+alarms (#{})::
+
+Alarms to call a function when the number of connections under a
+connection supervisor reaches or exceeds a defined treshold.
++
+The map keys are the alarm names, which can be any `term`. The
+associated values are the respective alarm options, again in a map
+with the following keys:
+
+type:::
+
+Must be set to `num_connections`.
+
+treshold:::
+
+Treshold value, which must be a `non_neg_integer`. When the
+number of connections under a connection supervisor reaches
+or exceeds this value, The alarm will trigger and call
+the function defined in the `callback` key (see below).
+
+callback:::
+
+The alarm function, which takes the listener name, the alarm
+name, the pid of the connection supervisor and a list of the pids
+of all connection processes under that supervisor as arguments.
+The return value is ignored.
+
+cooldown (5000):::
+
+The minimum time after which the alarm can be triggered again,
+in milliseconds.
 
 connection_type (worker)::
 

--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -55,7 +55,17 @@
 -type opts() :: any() | transport_opts(any()).
 -export_type([opts/0]).
 
+-type alarm_name() :: term().
+
+-type alarm_type() :: num_connections.
+
+-type alarm_opts() :: #{treshold => non_neg_integer(),
+			callback => fun((ref(), alarm_name(), pid(), [pid()]) -> any()) | {module(), atom()},
+			cooldown => non_neg_integer()}.
+-export_type([alarm_opts/0]).
+
 -type transport_opts(SocketOpts) :: #{
+	alarms => undefined | #{alarm_name() => {alarm_type(), alarm_opts()}},
 	connection_type => worker | supervisor,
 	handshake_timeout => timeout(),
 	logger => module(),
@@ -123,6 +133,18 @@ validate_transport_opt(max_connections, infinity, _) ->
 	true;
 validate_transport_opt(max_connections, Value, _) ->
 	is_integer(Value) andalso Value >= 0;
+validate_transport_opt(alarms, undefined, _) ->
+	true;
+validate_transport_opt(alarms, Alarms, _) ->
+	maps:fold(
+		fun
+			(_, {Type, Opts}, true) ->
+				validate_alarm(Type, Opts);
+			(_, _, false) ->
+				false
+		end,
+		true,
+		Alarms);
 validate_transport_opt(logger, Value, _) ->
 	is_atom(Value);
 validate_transport_opt(num_acceptors, Value, _) ->
@@ -143,6 +165,18 @@ validate_transport_opt(shutdown, Value, _) ->
 validate_transport_opt(socket_opts, _, _) ->
 	true;
 validate_transport_opt(_, _, _) ->
+	false.
+
+validate_alarm(num_connections, #{treshold := Treshold,
+		callback := Callback, cooldown := Cooldown}) ->
+	ValidTreshold = is_integer(Treshold) andalso Treshold >= 0,
+	ValidCooldown = is_integer(Cooldown) andalso Cooldown >= 0,
+	ValidCallback = case Callback of
+		{Mod, Fun} -> is_atom(Mod) andalso is_atom(Fun);
+		_ -> is_function(Callback, 4)
+	end,
+	ValidTreshold andalso ValidCooldown andalso ValidCallback;
+validate_alarm(_, _) ->
 	false.
 
 maybe_started({error, {{shutdown,

--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -59,7 +59,7 @@
 	type := Type,
 	callback := Callback,
 	treshold := non_neg_integer(),
-	cooldown := non_neg_integer()
+	cooldown => non_neg_integer()
 }.
 
 -type alarm_num_connections() :: alarm(num_connections, fun((ref(), term(), pid(), [pid()]) -> any())).
@@ -165,11 +165,16 @@ validate_transport_opt(socket_opts, _, _) ->
 validate_transport_opt(_, _, _) ->
 	false.
 
-validate_alarm(#{type := num_connections, treshold := Treshold,
-		callback := Callback, cooldown := Cooldown}) ->
+validate_alarm(Alarm = #{type := num_connections, treshold := Treshold,
+		callback := Callback}) ->
 	is_integer(Treshold) andalso Treshold >= 0
-	andalso is_integer(Cooldown) andalso Cooldown >= 0
-	andalso is_function(Callback, 4);
+	andalso is_function(Callback, 4)
+	andalso case Alarm of
+		#{cooldown := Cooldown} ->
+			is_integer(Cooldown) andalso Cooldown >= 0;
+		_ ->
+			true
+	end;
 validate_alarm(_) ->
 	false.
 

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -307,7 +307,10 @@ schedule_activate_alarm(_, _) ->
 get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
 	maps:fold(
 		fun
-			(Name, Opts = #{type := num_connections}, Acc) -> Acc#{Name => {Opts, undefined}};
+			(Name, Opts = #{type := num_connections, cooldown := _}, Acc) ->
+				Acc#{Name => {Opts, undefined}};
+			(Name, Opts = #{type := num_connections}, Acc) ->
+				Acc#{Name => {Opts#{cooldown => 5000}, undefined}};
 			(_, _, Acc) -> Acc
 		end,
 		#{},

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -43,7 +43,7 @@
 	handshake_timeout :: timeout(),
 	max_conns = undefined :: ranch:max_conns(),
 	stats_counters_ref :: counters:counters_ref(),
-	alarms = #{} :: #{ranch:alarm_name() => {undefined | reference(), ranch:alarm_opts()}},
+	alarms = #{} :: #{term() => {undefined | reference(), map()}},
 	logger = undefined :: module()
 }).
 
@@ -307,7 +307,7 @@ schedule_activate_alarm(_, _) ->
 get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
 	maps:fold(
 		fun
-			(Name, {num_connections, Opts}, Acc) -> Acc#{Name => {Opts, undefined}};
+			(Name, Opts = #{type := num_connections}, Acc) -> Acc#{Name => {Opts, undefined}};
 			(_, _, Acc) -> Acc
 		end,
 		#{},

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -43,7 +43,7 @@
 	handshake_timeout :: timeout(),
 	max_conns = undefined :: ranch:max_conns(),
 	stats_counters_ref :: counters:counters_ref(),
-	alarms = #{} :: #{term() => {undefined | reference(), map()}},
+	alarms = #{} :: #{term() => {map(), undefined | reference()}},
 	logger = undefined :: module()
 }).
 

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -43,6 +43,7 @@
 	handshake_timeout :: timeout(),
 	max_conns = undefined :: ranch:max_conns(),
 	stats_counters_ref :: counters:counters_ref(),
+	alarms = #{} :: #{ranch:alarm_name() => {undefined | reference(), ranch:alarm_opts()}},
 	logger = undefined :: module()
 }).
 
@@ -106,6 +107,7 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 	process_flag(trap_exit, true),
 	ok = ranch_server:set_connections_sup(Ref, Id, self()),
 	MaxConns = ranch_server:get_max_connections(Ref),
+	Alarms = get_alarms(TransOpts),
 	ConnType = maps:get(connection_type, TransOpts, worker),
 	Shutdown = maps:get(shutdown, TransOpts, 5000),
 	HandshakeTimeout = maps:get(handshake_timeout, TransOpts, 5000),
@@ -116,11 +118,12 @@ init(Parent, Ref, Id, Transport, TransOpts, Protocol, Logger) ->
 		shutdown=Shutdown, transport=Transport, protocol=Protocol,
 		opts=ProtoOpts, stats_counters_ref=StatsCounters,
 		handshake_timeout=HandshakeTimeout,
-		max_conns=MaxConns, logger=Logger}, 0, 0, []).
+		max_conns=MaxConns, alarms=Alarms,
+		logger=Logger}, 0, 0, []).
 
 loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 		transport=Transport, protocol=Protocol, opts=Opts, stats_counters_ref=StatsCounters,
-		max_conns=MaxConns, logger=Logger}, CurConns, NbChildren, Sleepers) ->
+		alarms=Alarms, max_conns=MaxConns, logger=Logger}, CurConns, NbChildren, Sleepers) ->
 	receive
 		{?MODULE, start_protocol, To, Socket} ->
 			try Protocol:start_link(Ref, Transport, Opts) of
@@ -181,6 +184,12 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 		{set_protocol_options, Opts2} ->
 			loop(State#state{opts=Opts2},
 				CurConns, NbChildren, Sleepers);
+		{timeout, _, {activate_alarm, AlarmName}} when is_map_key(AlarmName, Alarms) ->
+			{AlarmOpts, _} = maps:get(AlarmName, Alarms),
+			NewAlarm = trigger_alarm(Ref, AlarmName, {AlarmOpts, undefined}, CurConns),
+			loop(State#state{alarms=Alarms#{AlarmName => NewAlarm}}, CurConns, NbChildren, Sleepers);
+		{timeout, _, {activate_alarm, _}} ->
+			loop(State, CurConns, NbChildren, Sleepers);
 		{'EXIT', Parent, Reason} ->
 			terminate(State, Reason, NbChildren);
 		{'EXIT', Pid, Reason} when Sleepers =:= [] ->
@@ -245,18 +254,20 @@ loop(State=#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType,
 	end.
 
 handshake(State=#state{ref=Ref, transport=Transport, handshake_timeout=HandshakeTimeout,
-		max_conns=MaxConns}, CurConns, NbChildren, Sleepers, To, Socket, SupPid, ProtocolPid) ->
+		max_conns=MaxConns, alarms=Alarms0}, CurConns, NbChildren, Sleepers, To, Socket, SupPid, ProtocolPid) ->
 	case Transport:controlling_process(Socket, ProtocolPid) of
 		ok ->
 			ProtocolPid ! {handshake, Ref, Transport, Socket, HandshakeTimeout},
 			put(SupPid, active),
 			CurConns2 = CurConns + 1,
-			if CurConns2 < MaxConns ->
+			Sleepers2 = if CurConns2 < MaxConns ->
 					To ! self(),
-					loop(State, CurConns2, NbChildren + 1, Sleepers);
+					Sleepers;
 				true ->
-					loop(State, CurConns2, NbChildren + 1, [To|Sleepers])
-			end;
+					[To|Sleepers]
+			end,
+			Alarms1 = trigger_alarms(Ref, Alarms0, CurConns2),
+			loop(State#state{alarms=Alarms1}, CurConns2, NbChildren + 1, Sleepers2);
 		{error, _} ->
 			Transport:close(Socket),
 			%% Only kill the supervised pid, because the connection's pid,
@@ -265,6 +276,45 @@ handshake(State=#state{ref=Ref, transport=Transport, handshake_timeout=Handshake
 			To ! self(),
 			loop(State, CurConns, NbChildren, Sleepers)
 	end.
+
+trigger_alarms(Ref, Alarms, CurConns) ->
+	maps:map(
+		fun
+			(AlarmName, Alarm) ->
+				trigger_alarm(Ref, AlarmName, Alarm, CurConns)
+		end,
+		Alarms
+	).
+
+trigger_alarm(Ref, AlarmName, {Opts=#{treshold := Treshold, callback := Callback}, undefined}, CurConns) when CurConns >= Treshold ->
+	ActiveConns = [Pid || {Pid, active} <- get()],
+	case Callback of
+		{Mod, Fun} ->
+			spawn(Mod, Fun, [Ref, AlarmName, self(), ActiveConns]);
+		_ ->
+			Self = self(),
+			spawn(fun () -> Callback(Ref, AlarmName, Self, ActiveConns) end)
+	end,
+	{Opts, schedule_activate_alarm(AlarmName, Opts)};
+trigger_alarm(_, _, Alarm, _) ->
+	Alarm.
+
+schedule_activate_alarm(AlarmName, #{cooldown := Cooldown}) when Cooldown > 0 ->
+	erlang:start_timer(Cooldown, self(), {activate_alarm, AlarmName});
+schedule_activate_alarm(_, _) ->
+	undefined.
+
+get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
+	maps:fold(
+		fun
+			(Name, {num_connections, Opts}, Acc) -> Acc#{Name => {Opts, undefined}};
+			(_, _, Acc) -> Acc
+		end,
+		#{},
+		Alarms
+	);
+get_alarms(_) ->
+	#{}.
 
 set_transport_options(State=#state{max_conns=MaxConns0}, CurConns, NbChildren, Sleepers0, TransOpts) ->
 	MaxConns1 = maps:get(max_connections, TransOpts, 1024),
@@ -277,8 +327,68 @@ set_transport_options(State=#state{max_conns=MaxConns0}, CurConns, NbChildren, S
 		false ->
 			Sleepers0
 	end,
-	loop(State#state{max_conns=MaxConns1, handshake_timeout=HandshakeTimeout, shutdown=Shutdown},
+	State1=set_alarm_option(State, TransOpts, CurConns),
+	loop(State1#state{max_conns=MaxConns1, handshake_timeout=HandshakeTimeout, shutdown=Shutdown},
 		CurConns, NbChildren, Sleepers1).
+
+set_alarm_option(State=#state{ref=Ref, alarms=OldAlarms}, TransOpts, CurConns) ->
+	NewAlarms0 = get_alarms(TransOpts),
+	NewAlarms1 = merge_alarms(OldAlarms, NewAlarms0),
+	NewAlarms2 = trigger_alarms(Ref, NewAlarms1, CurConns),
+	State#state{alarms=NewAlarms2}.
+
+merge_alarms(Old, New) ->
+	OldList = lists:sort(maps:to_list(Old)),
+	NewList = lists:sort(maps:to_list(New)),
+	Merged = merge_alarms(OldList, NewList, []),
+	maps:from_list(Merged).
+
+merge_alarms([], News, Acc) ->
+	News ++ Acc;
+merge_alarms([{_, {_, undefined}}|Olds], [], Acc) ->
+	merge_alarms(Olds, [], Acc);
+merge_alarms([{_, {_, Timer}}|Olds], [], Acc) ->
+	_ = cancel_alarm_reactivation_timer(Timer),
+	merge_alarms(Olds, [], Acc);
+merge_alarms([{Name, {OldOpts, Timer}}|Olds], [{Name, {NewOpts, _}}|News], Acc) ->
+	merge_alarms(Olds, News, [{Name, {NewOpts, adapt_alarm_timer(Name, Timer, OldOpts, NewOpts)}}|Acc]);
+merge_alarms([{OldName, {_, Timer}}|Olds], News=[{NewName, _}|_], Acc) when OldName < NewName ->
+	_ = cancel_alarm_reactivation_timer(Timer),
+	merge_alarms(Olds, News, Acc);
+merge_alarms(Olds, [New|News], Acc) ->
+	merge_alarms(Olds, News, [New|Acc]).
+
+%% Not in cooldown.
+adapt_alarm_timer(_, undefined, _, _) ->
+	undefined;
+%% Cooldown unchanged.
+adapt_alarm_timer(_, Timer, #{cooldown := Cooldown}, #{cooldown := Cooldown}) ->
+	Timer;
+%% Cooldown changed to no cooldown, cancel cooldown timer.
+adapt_alarm_timer(_, Timer, _, #{cooldown := 0}) ->
+	_ = cancel_alarm_reactivation_timer(Timer),
+	undefined;
+%% Cooldown changed, cancel current and start new timer taking the already elapsed time into account.
+adapt_alarm_timer(Name, Timer, #{cooldown := OldCooldown}, #{cooldown := NewCooldown}) ->
+	OldTimeLeft = cancel_alarm_reactivation_timer(Timer),
+	case NewCooldown-OldCooldown+OldTimeLeft of
+		NewTimeLeft when NewTimeLeft>0 ->
+			erlang:start_timer(NewTimeLeft, self(), {activate_alarm, Name});
+		_ ->
+			undefined
+	end.
+
+cancel_alarm_reactivation_timer(Timer) ->
+	case erlang:cancel_timer(Timer) of
+		%% Timer had already expired when we tried to cancel it, so we flush the
+		%% reactivation message it sent and return 0 as remaining time.
+		false ->
+			ok = receive {timeout, Timer, {activate_alarm, _}} -> ok after 0 -> ok end,
+			0;
+		%% Timer has not yet expired, we return the amount of time that was remaining.
+		TimeLeft ->
+			TimeLeft
+	end.
 
 -spec terminate(#state{}, any(), non_neg_integer()) -> no_return().
 terminate(#state{shutdown=brutal_kill, id=Id,

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -587,8 +587,8 @@ misc_connection_alarms(_) ->
 		Self ! {connection_alarm, {Ref, AlarmName, length(ActiveConns)}}
 	end,
 	Alarms0 = #{
-		test1 => {num_connections, AlarmOpts1 = #{treshold => 2, cooldown => 0, callback => AlarmCallback}},
-		test2 => {num_connections, AlarmOpts2 = #{treshold => 3, cooldown => 0, callback => AlarmCallback}}
+		test1 => Alarm1 = #{type => num_connections, treshold => 2, cooldown => 0, callback => AlarmCallback},
+		test2 => Alarm2 = #{type => num_connections, treshold => 3, cooldown => 0, callback => AlarmCallback}
 	},
 	ConnectOpts = [binary, {active, false}, {packet, raw}],
 
@@ -609,8 +609,8 @@ misc_connection_alarms(_) ->
 	#{test1 := 3, test2 := 3} = do_recv_connection_alarms(Name, 100),
 
 	Alarms1 = #{
-		test1 => {num_connections, AlarmOpts1#{cooldown => 100}},
-		test2 => {num_connections, AlarmOpts2#{cooldown => 100}}
+		test1 => Alarm1#{cooldown => 100},
+		test2 => Alarm2#{cooldown => 100}
 	},
 	ok = ranch:set_transport_options(Name, TransOpts0#{alarms => Alarms1}),
 	ok = do_flush_connection_alarms(Name),


### PR DESCRIPTION
Rough draft for #281, for discussion.

Points to discuss:
* format and naming of the alarm transport option
* alarm reactivation message probably shouldn't be that blunt
* ~allow MFA instead/additionally to a callback fun~
* ~call callback fun in a separate process so it doesn't block the conns sup, or leave that up to the user~
* arguments to the callback fun (currently ~only conns sup pid~ listener ref, conns_sup pid, and list of active connection pids); ~listener ref and pids of connections would also make sense;~ anything else that would make sense?
* ~with this implementation, alarms will only be triggered when a new connection arrives at the conns sup, not periodically~