### PR TITLE
Fix ranch_server ETS table before match in get_listener_sups/0

### DIFF
--- a/src/ranch_server.erl
+++ b/src/ranch_server.erl
@@ -118,7 +118,10 @@ get_listener_sup(Ref) ->
 
 -spec get_listener_sups() -> [{ranch:ref(), pid()}].
 get_listener_sups() ->
-	[{Ref, Pid} || [Ref, Pid] <- ets:match(?TAB, {{listener_sup, '$1'}, '$2'})].
+	ets:safe_fixtable(?TAB, true),
+	Result = [{Ref, Pid} || [Ref, Pid] <- ets:match(?TAB, {{listener_sup, '$1'}, '$2'})],
+	ets:safe_fixtable(?TAB, false),
+	Result.
 
 -spec set_addr(ranch:ref(), {inet:ip_address(), inet:port_number()} |
 	{local, binary()} | {undefined, undefined}) -> ok.


### PR DESCRIPTION
It was easy to make get_listener_sups/0 crash before this - probably when the ?TAB was not yet created.

I used to get this error:
```Erlang{badarg,
 [{ets,match,
   [ranch_server,
    {{listener_sup,
      '$1'},
     '$2'}],
   []},
  {ranch_server,
   get_listener_sups,
   0,
   [{file,
     ".../ranch/src/ranch_server.erl"},
    {line,105}]},
  {ranch,info,0,
   [{file,
     ".../ranch/src/ranch.erl"},
    {line,334}]},
...
```