### PR TITLE
Delete possibly existing socket file when listening on a local socket

### DIFF
--- a/src/ranch.erl
+++ b/src/ranch.erl
@@ -155,10 +155,13 @@ start_error(_, Error) -> Error.
 
 -spec stop_listener(ref()) -> ok | {error, not_found}.
 stop_listener(Ref) ->
+	[_, Transport, _, _, _] = ranch_server:get_listener_start_args(Ref),
+	TransOpts = get_transport_options(Ref),
 	case supervisor:terminate_child(ranch_sup, {ranch_listener_sup, Ref}) of
 		ok ->
 			_ = supervisor:delete_child(ranch_sup, {ranch_listener_sup, Ref}),
-			ranch_server:cleanup_listener_opts(Ref);
+			ranch_server:cleanup_listener_opts(Ref),
+			Transport:cleanup(TransOpts);
 		{error, Reason} ->
 			{error, Reason}
 	end.

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -124,6 +124,15 @@ do_listen(SocketOpts0, Logger) ->
 	SocketOpts2 = ranch:set_option_default(SocketOpts1, nodelay, true),
 	SocketOpts3 = ranch:set_option_default(SocketOpts2, send_timeout, 30000),
 	SocketOpts = ranch:set_option_default(SocketOpts3, send_timeout_close, true),
+	%% In case of a local socket, we remove the socket file first.
+	%% It is possible to have multiple ip tuples in the socket options,
+	%% and the last one will be used (undocumented).
+	_ = case lists:keyfind(ip, 1, lists:reverse(SocketOpts0)) of
+		{ip, {local, SockFile}} ->
+			file:delete(SockFile);
+		_ ->
+			ok
+	end,
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -92,6 +92,15 @@ listen(TransOpts) ->
 	SocketOpts2 = ranch:set_option_default(SocketOpts1, nodelay, true),
 	SocketOpts3 = ranch:set_option_default(SocketOpts2, send_timeout, 30000),
 	SocketOpts4 = ranch:set_option_default(SocketOpts3, send_timeout_close, true),
+	%% In case of a local socket, we remove the socket file first.
+	%% It is possible to have multiple ip tuples in the socket options,
+	%% and the last one will be used (undocumented).
+	_ = case lists:keyfind(ip, 1, lists:reverse(SocketOpts0)) of
+		{ip, {local, SockFile}} ->
+			file:delete(SockFile);
+		_ ->
+			ok
+	end,
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -66,6 +66,7 @@
 -callback shutdown(socket(), read | write | read_write)
 	-> ok | {error, atom()}.
 -callback close(socket()) -> ok.
+-callback cleanup(ranch:transport_opts(any())) -> ok.
 
 %% A fallback for transports that don't have a native sendfile implementation.
 %% Note that the ordering of arguments is different from file:sendfile/5 and


### PR DESCRIPTION
As discussed on IRC, this PR removes a possibly existing socket file when a listener is configured to listen on a local socket.