### PR TITLE
Fix typo in comment explictly -> explicitly

### DIFF
--- a/src/ranch_server.erl
+++ b/src/ranch_server.erl
@@ -77,7 +77,7 @@ cleanup_listener_opts(Ref) ->
 	%% cases when calling stop_listener followed by get_connections_sup,
 	%% we could end up with the pid still being returned, when we
 	%% expected a crash (because the listener was stopped).
-	%% Deleting it explictly here removes any possible confusion.
+	%% Deleting it explicitly here removes any possible confusion.
 	_ = ets:match_delete(?TAB, {{conns_sup, Ref, '_'}, '_'}),
 	%% Ditto for the listener supervisor.
 	_ = ets:delete(?TAB, {listener_sup, Ref}),


### PR DESCRIPTION
This PR fixes a tiny typo in a comment