### PR TITLE
Docs: {get,set}_{protocol,transport}_options

### DIFF
--- a/doc/src/manual/ranch.get_transport_options.asciidoc
+++ b/doc/src/manual/ranch.get_transport_options.asciidoc
@@ -9,7 +9,7 @@ ranch:get_transport_options - Get the current transport options
 [source,erlang]
 ----
 get_transport_options(Ref :: ranch:ref())
-    -> TransOpts :: any()
+    -> TransOpts :: ranch:transport_opts(any())
 ----
 
 Get the current transport options.
@@ -23,6 +23,11 @@ The listener name.
 == Return value
 
 The current transport options are returned.
+
+If the transport options were specified as only socket options (not a map) using
+link:man:ranch:start_listener(3)[ranch:start_listener(3)] or
+link:man:ranch:set_transport_options(3)[ranch:set_transport_options(3)], they
+are returned as `#{socket_opts => SocketOpts}`.
 
 == Examples
 

--- a/doc/src/manual/ranch.set_protocol_options.asciidoc
+++ b/doc/src/manual/ranch.set_protocol_options.asciidoc
@@ -18,6 +18,11 @@ Set the protocol options.
 The change will be applied immediately for all new connections.
 Old connections will not receive the new options.
 
+Note that the complete set of protocol options is replaced. To update a subset
+of the options, it is recommended to get the current protocol options using
+link:man:ranch:get_protocol_options(3)[ranch:get_protocol_options(3)], update
+them and then set them back using this function.
+
 == Arguments
 
 Ref::
@@ -37,6 +42,14 @@ The atom `ok` is always returned. It can be safely ignored.
 .Set the protocol options
 [source,erlang]
 ----
+ranch:set_protocol_options(example, ProtoOpts).
+----
+
+.Update some of the protocol options
+[source,erlang]
+----
+ProtoOpts0 = ranch:get_protocol_options(example),
+ProtoOpts = ProtoOpts0#{request_timeout => 2000},
 ranch:set_protocol_options(example, ProtoOpts).
 ----
 

--- a/doc/src/manual/ranch.set_transport_options.asciidoc
+++ b/doc/src/manual/ranch.set_transport_options.asciidoc
@@ -15,6 +15,11 @@ set_transport_options(Ref       :: ranch:ref(),
 
 Set the transport options.
 
+The complete set of transport options is replaced. To update a subset of the
+transport options, it is recommended to get the current transport options using
+link:man:ranch:get_transport_options(3)[ranch:get_transport_options(3)], update
+them and then set them back using this function.
+
 Changes to the following options will take effect...
 
 * immediately:
@@ -60,6 +65,20 @@ transport options contain invalid values.
 [source,erlang]
 ----
 Ref = example,
+
+ok = ranch:suspend_listener(Ref),
+ok = ranch:set_transport_options(Ref, TransOpts),
+ok = ranch:resume_listener(Ref).
+----
+
+.Update the listener TCP port within the `socket_opts` transport option
+[source,erlang]
+----
+Ref = example,
+TransOpts0 = ranch:get_transport_options(Ref),
+#{socket_opts = SocketOpts0} = TransOpts0,
+SocketOpts = [{port, 12345} | proplists:delete(port, SocketOpts0)],
+TransOpts = TransOpts0#{socket_opts = SocketOpts},
 
 ok = ranch:suspend_listener(Ref),
 ok = ranch:set_transport_options(Ref, TransOpts),


### PR DESCRIPTION
Clarifications and examples updated.

A development team contacted me for help regarding this. They didn't realize the complete options are overwritten by `set_{protocol,transport}_options/2`, including options set implicitly by Cowboy such as `connection_type => supervisor`. I guess they thought that only the options provided in the map to would be set. I recommended using the corresponding get function first, update the result and then set it.

This documentation update can help others avoid this confusion.