### PR TITLE
strip out options unsupported in TLS1.3 before listening on socket

### DIFF
--- a/src/ranch_acceptors_sup.erl
+++ b/src/ranch_acceptors_sup.erl
@@ -26,8 +26,7 @@ start_link(Ref, Transport, Logger) ->
 
 -spec init([term()]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([Ref, Transport, Logger]) ->
-	TransOptsTemp = ranch_server:get_transport_options(Ref),
-	TransOpts = strip_usupported_options(TransOptsTemp),
+	TransOpts = ranch_server:get_transport_options(Ref),
 	NumAcceptors = maps:get(num_acceptors, TransOpts, 10),
 	NumListenSockets = maps:get(num_listen_sockets, TransOpts, 1),
 	LSockets = case get(lsockets) of
@@ -101,20 +100,3 @@ format_error(reuseport_local) ->
 	"num_listen_sockets must be set to 1 for local sockets";
 format_error(Reason) ->
 	inet:format_error(Reason).
-
--spec strip_usupported_options(ranch:transport_opts(ranch_ssl:opts())) -> ranch:transport_opts(ranch_ssl:opts()).
-strip_usupported_options(#{socket_opts := SockOpts} = AllOpts) ->
-	case lists:keyfind(versions, 1, SockOpts) of
-		{versions, ['tlsv1.3']} ->
-			Intermediate1 = lists:keydelete(secure_renegotiate, 1, SockOpts),
-			Intermediate2 = lists:keydelete(reuse_sessions, 1, Intermediate1),
-			Intermediate3 = lists:keydelete(next_protocols_advertised, 1, Intermediate2),
-			NewSockOpts = lists:keydelete(alpn_preferred_protocols, 1, Intermediate3),
-			NewTransOpts = maps:update(socket_opts, NewSockOpts, AllOpts),
-			NewTransOpts;
-		_ ->
-			AllOpts
-	end;
-strip_usupported_options(AllOpts) ->
-	AllOpts.
-

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -309,6 +309,11 @@ strip_unsupported_options(SocketOpts) ->
                 (_) ->
                     true
                 end, SocketOpts),
+            if
+                NewSocketOpts /= SocketOpts ->
+                    error_logger:warning_msg("~p~n dropping options unsupported by TLS1.3-only ssl sockets: " ++
+                    "secure_renegotiate, reuse_sessions, next_protocols_advertised and/or alpn_preferred_protocols from ~p~n", [?MODULE, SocketOpts])
+            end,
             NewSocketOpts;
         true ->
             SocketOpts

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -129,7 +129,8 @@ do_listen(SocketOpts0, Logger) ->
 	SocketOpts1 = ranch:set_option_default(SocketOpts0, backlog, 1024),
 	SocketOpts2 = ranch:set_option_default(SocketOpts1, nodelay, true),
 	SocketOpts3 = ranch:set_option_default(SocketOpts2, send_timeout, 30000),
-	SocketOpts = ranch:set_option_default(SocketOpts3, send_timeout_close, true),
+	SocketOpts4 = ranch:set_option_default(SocketOpts3, send_timeout_close, true),
+	SocketOpts = strip_usupported_options(SocketOpts4),
 	%% We set the port to 0 because it is given in the Opts directly.
 	%% The port in the options takes precedence over the one in the
 	%% first argument.
@@ -296,3 +297,18 @@ cleanup(#{socket_opts:=SocketOpts}) ->
 	end;
 cleanup(_) ->
 	ok.
+
+-spec strip_usupported_options(opts()) -> opts().
+strip_usupported_options(SocketOpts) ->
+    case lists:keyfind(versions, 1, SocketOpts) of
+        {versions, ['tlsv1.3']} ->
+            Intermediate1 = lists:keydelete(secure_renegotiate, 1, SocketOpts),
+            Intermediate2 = lists:keydelete(reuse_sessions, 1, Intermediate1),
+            Intermediate3 = lists:keydelete(next_protocols_advertised, 1, Intermediate2),
+            lists:keydelete(alpn_preferred_protocols, 1, Intermediate3);
+        _ ->
+            SocketOpts
+    end;
+strip_usupported_options(SocketOpts) ->
+    SocketOpts.
+


### PR DESCRIPTION
These four options to secure earlier TLS versions are actually unsupported by TLS1.3 and are sometimes added by default (e.g. in Plug and Plug Cowboy):
- secure_renegotiate
- reuse_sessions
- next_protocols_advertised
- alpn_preferred_protocols

When earlier versions aren't being enabled, this gives an error from OTP SSL module. Remove these options if TLS1.3 is the only enabled protocol, to get around this error.