### PR TITLE
Enable TLS-PSK auth

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -117,7 +117,8 @@ listen(TransOpts) ->
 	case lists:keymember(cert, 1, SocketOpts)
 			orelse lists:keymember(certfile, 1, SocketOpts)
 			orelse lists:keymember(sni_fun, 1, SocketOpts)
-			orelse lists:keymember(sni_hosts, 1, SocketOpts) of
+			orelse lists:keymember(sni_hosts, 1, SocketOpts)
+			orelse lists:keymember(user_lookup_fun, 1, SocketOpts) of
 		true ->
 			Logger = maps:get(logger, TransOpts, logger),
 			do_listen(SocketOpts, Logger);


### PR DESCRIPTION
If we need only TLS-PSK authentication (without additional certificates, sni, etc) cowboy returns `{error, no_cert}` for `cowboy:start_tls/3`. Actually this is regular way to use PSK, althouht it's rare.
Sample config for this case:
```elixir
%{
  num_acceptors: 4,
  max_connections: 1024,
  socket_opts: [
    {:protocol, :tls},
    {:port, 12123},
    {:handshake, :full},
    {:ciphers,
      [
        %{cipher: :aes_256_gcm, key_exchange: :psk, mac: :aead, prf: :sha384}
      ]},
    {:user_lookup_fun, {&Hota.Api.Http.PskLookup.lookup/3, <<>>}}
  ]
}
```


