### PR TITLE
Introduce ranch_transport:peercert/1 callback

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -43,6 +43,7 @@
 -export([controlling_process/2]).
 -export([peername/1]).
 -export([sockname/1]).
+-export([peercert/1]).
 -export([shutdown/2]).
 -export([close/1]).
 -export([cleanup/1]).
@@ -295,6 +296,11 @@ peername(Socket) ->
 	-> {ok, {inet:ip_address(), inet:port_number()} | {local, binary()}} | {error, atom()}.
 sockname(Socket) ->
 	ssl:sockname(Socket).
+
+-spec peercert(ssl:sslsocket())
+	-> {ok, public_key:der_encoded()} | {error, any()}.
+peercert(Socket) ->
+	ssl:peercert(Socket).
 
 -spec shutdown(ssl:sslsocket(), read | write | read_write)
 	-> ok | {error, atom()}.

--- a/src/ranch_tcp.erl
+++ b/src/ranch_tcp.erl
@@ -42,6 +42,7 @@
 -export([controlling_process/2]).
 -export([peername/1]).
 -export([sockname/1]).
+-export([peercert/1]).
 -export([shutdown/2]).
 -export([close/1]).
 -export([cleanup/1]).
@@ -264,6 +265,10 @@ peername(Socket) ->
 	-> {ok, {inet:ip_address(), inet:port_number()} | {local, binary()}} | {error, atom()}.
 sockname(Socket) ->
 	inet:sockname(Socket).
+
+-spec peercert(inet:socket()) -> no_return().
+peercert(_Socket) ->
+	error(not_supported).
 
 -spec shutdown(inet:socket(), read | write | read_write)
 	-> ok | {error, atom()}.

--- a/src/ranch_transport.erl
+++ b/src/ranch_transport.erl
@@ -64,6 +64,7 @@
 	-> {ok, {inet:ip_address(), inet:port_number()} | {local, binary()}} | {error, atom()}.
 -callback sockname(socket())
 	-> {ok, {inet:ip_address(), inet:port_number()} | {local, binary()}} | {error, atom()}.
+-callback peercert(socket()) -> {ok, public_key:der_encoded()} | {error, any()}.
 -callback shutdown(socket(), read | write | read_write)
 	-> ok | {error, atom()}.
 -callback close(socket()) -> ok.

--- a/test/ranch_erlang_transport.erl
+++ b/test/ranch_erlang_transport.erl
@@ -40,6 +40,7 @@
 -export([controlling_process/2]).
 -export([peername/1]).
 -export([sockname/1]).
+-export([peercert/1]).
 -export([shutdown/2]).
 -export([close/1]).
 -export([cleanup/1]).
@@ -159,6 +160,11 @@ peername(_Socket) ->
 	-> {ok, {inet:ip_address(), inet:port_number()} | {local, binary()}} | {error, atom()}.
 sockname(_Socket) ->
 	{ok, {{127, 0, 0, 1}, 12710}}.
+
+-spec peercert(reference())
+	-> no_return().
+peercert(_Socket) ->
+	error(not_supported).
 
 -spec shutdown(reference(), read | write | read_write)
 	-> ok | {error, atom()}.


### PR DESCRIPTION
This callback should be used from cowboy_http and cowboy_http2 instead of a direct call to ssl:peercert/1.