### PR TITLE
Fix upgrade suite for 2.1

### DIFF
--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -471,25 +471,6 @@ system_terminate(Reason, _, _, {State, _, NbChildren, _}) ->
 	terminate(State, Reason, NbChildren).
 
 -spec system_code_change(any(), _, _, _) -> {ok, any()}.
-system_code_change({#state{parent=Parent, ref=Ref, conn_type=ConnType,
-		shutdown=Shutdown, transport=Transport, protocol=Protocol,
-		opts=Opts, handshake_timeout=HandshakeTimeout,
-		max_conns=MaxConns, logger=Logger}, CurConns, NbChildren,
-		Sleepers}, _, {down, _}, _) ->
-	{ok, {{state, Parent, Ref, ConnType, Shutdown, Transport, Protocol,
-		Opts, HandshakeTimeout, MaxConns, Logger}, CurConns, NbChildren,
-		Sleepers}};
-system_code_change({{state, Parent, Ref, ConnType, Shutdown, Transport, Protocol,
-		Opts, HandshakeTimeout, MaxConns, Logger}, CurConns, NbChildren,
-		Sleepers}, _, _, _) ->
-	Self = self(),
-	[Id] = [Id || {Id, Pid} <- ranch_server:get_connections_sups(Ref), Pid=:=Self],
-	StatsCounters = ranch_server:get_stats_counters(Ref),
-	{ok, {#state{parent=Parent, ref=Ref, id=Id, conn_type=ConnType, shutdown=Shutdown,
-		transport=Transport, protocol=Protocol, opts=Opts,
-		handshake_timeout=HandshakeTimeout, max_conns=MaxConns,
-		stats_counters_ref=StatsCounters,
-		logger=Logger}, CurConns, NbChildren, Sleepers}};
 system_code_change(Misc, _, _, _) ->
 	{ok, Misc}.
 

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -160,6 +160,14 @@ init_per_group(_, Config) ->
 end_per_group(_, _) ->
 	ok.
 
+init_per_testcase(_, Config) ->
+	Config.
+
+end_per_testcase(_, _) ->
+	%% Stop all listeners that a test case may have left running.
+	_ = [catch ranch:stop_listener(Name) || Name <- maps:keys(ranch:info())],
+	ok.
+
 %% misc.
 
 misc_bad_transport(_) ->


### PR DESCRIPTION
The upgrade suite failed since 2.1 was released. Current PRs should be rebased on master when this one is merged in order to make the CI tests pass.