### PR TITLE
Allow new ssl option certs_keys in ranch_ssl

### DIFF
--- a/doc/src/manual/ranch_ssl.asciidoc
+++ b/doc/src/manual/ranch_ssl.asciidoc
@@ -45,6 +45,11 @@ ssl_opt() = {alpn_preferred_protocols, [binary()]}
           | {cacertfile, file:filename()}
           | {cacerts, [public_key:der_encoded()]}
           | {cert, public_key:der_encoded()}
+          | {certs_keys, [#{cert => public_key:der_encoded(),
+                            key => ssl:key(),
+                            certfile => file:filename(),
+                            keyfile => file:filename(),
+                            key_pem_password => iodata() | fun(() -> iodata())}]}
           | {certfile, file:filename()}
           | {ciphers, ssl:ciphers()}
           | {client_renegotiation, boolean()}
@@ -122,6 +127,12 @@ List of DER encoded trusted certificates.
 cert::
 
 DER encoded user certificate.
+
+certs_keys::
+
+A list of a certificate (or possible a certificate and its chain)
+and the associated key of the certificate, that may be used to
+authenticate the client or the server.
 
 certfile::
 

--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -53,6 +53,11 @@
 	| {cacertfile, file:filename()}
 	| {cacerts, [public_key:der_encoded()]}
 	| {cert, public_key:der_encoded()}
+	| {certs_keys, [#{cert => public_key:der_encoded(),
+			  key => ssl:key(),
+			  certfile => file:filename(),
+			  keyfile => file:filename(),
+			  key_pem_password => iodata() | fun(() -> iodata())}]}
 	| {certfile, file:filename()}
 	| {ciphers, ssl:ciphers()}
 	| {client_renegotiation, boolean()}
@@ -119,7 +124,8 @@ listen(TransOpts) ->
 			orelse lists:keymember(certfile, 1, SocketOpts)
 			orelse lists:keymember(sni_fun, 1, SocketOpts)
 			orelse lists:keymember(sni_hosts, 1, SocketOpts)
-			orelse lists:keymember(user_lookup_fun, 1, SocketOpts) of
+			orelse lists:keymember(user_lookup_fun, 1, SocketOpts)
+			orelse lists:keymember(certs_keys, 1, SocketOpts) of
 		true ->
 			Logger = maps:get(logger, TransOpts, logger),
 			do_listen(SocketOpts, Logger);


### PR DESCRIPTION
See #342.

The ssl_opts are a drag... :roll_eyes:

No tests, it looks like many ssl tests are broken for OTP 25 anyway :frowning_face: