### PR TITLE
Fix alarm setting typo `treshold` -> `threshold`

### DIFF
--- a/doc/src/guide/listeners.asciidoc
+++ b/doc/src/guide/listeners.asciidoc
@@ -332,14 +332,14 @@ processes.
 
 The `alarms` transport option allows you to configure alarms
 which will be triggered when the number of connections tracked
-by one connection supervisor reaches or exceeds the defined treshold.
+by one connection supervisor reaches or exceeds the defined threshold.
 
 The `alarms` transport option takes a map with alarm names as keys and alarm
 options as values.
 
 Any term is allowed as an alarm name.
 
-Alarm options include the alarm type and a treshold that, when reached,
+Alarm options include the alarm type and a threshold that, when reached,
 triggers the given callback. A cooldown prevents the alarm from being
 triggered too often.
 
@@ -350,7 +350,7 @@ triggered too often.
 Alarms = #{
     my_alarm => #{
         type => num_connections,
-        treshold => 100,
+        threshold => 100,
         callback => fun(Ref, Name, ConnSup, ConnPids]) ->
             logger:warning("Warning (~s): "
                     "Supervisor ~s of listener ~s "

--- a/doc/src/guide/migrating_from_2.0.asciidoc
+++ b/doc/src/guide/migrating_from_2.0.asciidoc
@@ -18,7 +18,7 @@ for Erlang/OTP 21 has been removed.
 
 * Alarms can now be configured. The only alarm currently
   available is `num_connections`. When the number of
-  connections goes over a configurable treshold Ranch
+  connections goes over a configurable threshold Ranch
   will call the given callback. This can be used to
   programmatically shut down idle connections to
   make up space for new connections, for example.

--- a/doc/src/manual/ranch.asciidoc
+++ b/doc/src/manual/ranch.asciidoc
@@ -91,7 +91,7 @@ transport_opts(SocketOpts) = #{
     alarms               => #{
                                 term() => #{
                                     type := num_connections,
-                                    treshold := non_neg_integer(),
+                                    threshold := non_neg_integer(),
                                     callback := fun((ref(), term(), pid(), [pid()]) -> any()),
                                     cooldown => non_neg_integer()
                                 }
@@ -118,7 +118,7 @@ None of the options are required.
 alarms (#{})::
 
 Alarms to call a function when the number of connections tracked
-by one connection supervisor reaches or exceeds a defined treshold.
+by one connection supervisor reaches or exceeds a defined threshold.
 +
 The map keys are the alarm names, which can be any `term`. The
 associated values are the respective alarm options, again in a map
@@ -128,9 +128,9 @@ type:::
 
 Must be set to `num_connections`.
 
-treshold:::
+threshold:::
 
-Treshold value, which must be a `non_neg_integer`. When the
+Threshold value, which must be a `non_neg_integer`. When the
 number of connections tracked by a single connection supervisor
 reaches or exceeds this value, The alarm will trigger and call
 the function defined in the `callback` key (see below).

--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -287,7 +287,7 @@ trigger_alarms(Ref, Alarms, CurConns) ->
 		Alarms
 	).
 
-trigger_alarm(Ref, AlarmName, {Opts=#{treshold := Treshold, callback := Callback}, undefined}, CurConns) when CurConns >= Treshold ->
+trigger_alarm(Ref, AlarmName, {Opts=#{threshold := Threshold, callback := Callback}, undefined}, CurConns) when CurConns >= Threshold ->
 	ActiveConns = [Pid || {Pid, active} <- get()],
 	case Callback of
 		{Mod, Fun} ->
@@ -306,6 +306,7 @@ schedule_activate_alarm(_, _) ->
 	undefined.
 
 get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
+	Alarms1 = ranch:compat_normalize_alarms_option(Alarms),
 	maps:fold(
 		fun
 			(Name, Opts = #{type := num_connections, cooldown := _}, Acc) ->
@@ -315,7 +316,7 @@ get_alarms(#{alarms := Alarms}) when is_map(Alarms) ->
 			(_, _, Acc) -> Acc
 		end,
 		#{},
-		Alarms
+		Alarms1
 	);
 get_alarms(_) ->
 	#{}.

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -598,6 +598,8 @@ misc_connection_alarms(_) ->
 	end,
 	Alarms0 = #{
 		test1 => Alarm1 = #{type => num_connections, threshold => 2, cooldown => 0, callback => AlarmCallback},
+		%% The test2 alarm uses the misspelled treshold key to test for backwards compatibility.
+		%% @TODO: Change to use the proper spelling when treshold gets removed in Ranch 3.0.
 		test2 => Alarm2 = #{type => num_connections, treshold => 3, cooldown => 0, callback => AlarmCallback}
 	},
 	ConnectOpts = [binary, {active, false}, {packet, raw}],

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -597,7 +597,7 @@ misc_connection_alarms(_) ->
 		Self ! {connection_alarm, {Ref, AlarmName, length(ActiveConns)}}
 	end,
 	Alarms0 = #{
-		test1 => Alarm1 = #{type => num_connections, treshold => 2, cooldown => 0, callback => AlarmCallback},
+		test1 => Alarm1 = #{type => num_connections, threshold => 2, cooldown => 0, callback => AlarmCallback},
 		test2 => Alarm2 = #{type => num_connections, treshold => 3, cooldown => 0, callback => AlarmCallback}
 	},
 	ConnectOpts = [binary, {active, false}, {packet, raw}],


### PR DESCRIPTION
Fixes #349.

The misspelled option `treshold` is still accepted by `ranch:start_listener/5` and `ranch:set_transport_options/2`, and will be normalized to `threshold` internally. The transport options are however stored in `ranch_server` as they were given (ie, with possibly misspelled `treshold`s), such that `ranch:get_transport_options/1` returns them unchanged. It would have been easier to store them normalized, but there is an (admittedly off) chance that this may break existing code which has expectations as to the naming of the key in the return from `ranch:get_transport_options/1`.

I also changed the `alarm` type by changing the `treshold` key to `threshold`. I did, however, not do anything to also allow the `treshold` key there, so dialyzer _may_ (ie, I didn't check) complain on existing code using it. I think this is just as well, since it would serve as an incentive to adapt.

The documentation has been adapted by replacing all occurrences of "treshold" or "Treshold" with "threshold" or "Threshold", respectively. The `treshold` key is now effectively undocumented.

The respective test `acceptor_SUITE:misc_connection_alarms`, which uses two alarms, has been changed such that one uses the properly spelled and one the misspelled option.