### PR TITLE
Fix OTP29 compilation

### DIFF
--- a/src/ranch_conns_sup.erl
+++ b/src/ranch_conns_sup.erl
@@ -86,8 +86,10 @@ start_protocol(SupPid, MonitorRef, Socket) ->
 -spec active_connections(pid()) -> non_neg_integer().
 active_connections(SupPid) ->
 	Tag = erlang:monitor(process, SupPid),
-	catch erlang:send(SupPid, {?MODULE, active_connections, self(), Tag},
-		[noconnect]),
+    try erlang:send(SupPid, {?MODULE, active_connections, self(), Tag}, [noconnect])
+    catch
+        _:_ -> ok
+    end,
 	receive
 		{Tag, Ret} ->
 			erlang:demonitor(Tag, [flush]),

--- a/test/acceptor_SUITE.erl
+++ b/test/acceptor_SUITE.erl
@@ -17,6 +17,7 @@
 -module(acceptor_SUITE).
 -compile(export_all).
 -compile(nowarn_export_all).
+-compile(nowarn_deprecated_catch).
 
 -dialyzer({nowarn_function, misc_wait_for_connections/1}).
 %% @todo Remove when specs in ssl are updated to accept local addresses.
@@ -600,12 +601,11 @@ misc_connection_alarms(_) ->
 	AlarmCallback = fun (Ref, AlarmName, _, ActiveConns) ->
 		Self ! {connection_alarm, {Ref, AlarmName, length(ActiveConns)}}
 	end,
-	Alarms0 = #{
-		test1 => Alarm1 = #{type => num_connections, threshold => 2, cooldown => 0, callback => AlarmCallback},
-		%% The test2 alarm uses the misspelled treshold key to test for backwards compatibility.
-		%% @TODO: Change to use the proper spelling when treshold gets removed in Ranch 3.0.
-		test2 => Alarm2 = #{type => num_connections, treshold => 3, cooldown => 0, callback => AlarmCallback}
-	},
+	Alarm1 = #{type => num_connections, threshold => 2, cooldown => 0, callback => AlarmCallback},
+	%% The test2 alarm uses the misspelled treshold key to test for backwards compatibility.
+	%% @TODO: Change to use the proper spelling when treshold gets removed in Ranch 3.0.
+	Alarm2 = #{type => num_connections, treshold => 3, cooldown => 0, callback => AlarmCallback},
+	Alarms0 = #{test1 => Alarm1, test2 => Alarm2},
 	ConnectOpts = [binary, {active, false}, {packet, raw}],
 
 	{ok, _} = ranch:start_listener(Name, ranch_tcp,


### PR DESCRIPTION
Other than the deprecated `catch`, of which there are hundreds in the `acceptor_SUITE` and therefore chose to just add a nowarn flag, there was also 
```
﻿     ┌─ test/acceptor_SUITE.erl:
     │
 629 │  		test1 => Alarm1#{cooldown => 100},
     │  		         ╰── Warning: variable 'Alarm1' exported from map (line 604, column 12).
Exporting bindings from subexpressions other than block expressions is
deprecated and may yield an error in a future version of Erlang/OTP.
Please move the binding of 'Alarm1' out of the map.
Compile directive 'nowarn_export_var_subexpr' can be used to suppress
warnings in selected modules.
```